### PR TITLE
fix(deps): pin phaser to ^3.90.0 (phaser3-rex-plugins is Phaser-3 only)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|less|sass|scss)$': '<rootDir>/tests/mocks/styleMock.js',
     '\\.(gif|ttf|eot|svg|png|mp3|ogg)$': '<rootDir>/tests/mocks/fileMock.js',
+    '^phaser3spectorjs$': '<rootDir>/tests/mocks/fileMock.js',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "phaser": "^4.0.0",
+        "phaser": "^3.90.0",
         "phaser3-rex-plugins": "^1.80.20",
         "regenerator-runtime": "^0.14.1"
       },
@@ -11661,12 +11661,12 @@
       "license": "MIT"
     },
     "node_modules/phaser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/phaser/-/phaser-4.0.0.tgz",
-      "integrity": "sha512-f9oYpu3/UymB5JJDZRqOsNQm5FkMMC7u8eL8yQuqGAa54wTbgE2QbTOn70vgvlOVuYeQcw2mOQ52PpJHBSBkfQ==",
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
+      "integrity": "sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.4"
+        "eventemitter3": "^5.0.1"
       }
     },
     "node_modules/phaser3-rex-plugins": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "unsplash-js": "^7.0.20"
   },
   "dependencies": {
-    "phaser": "^4.0.0",
+    "phaser": "^3.90.0",
     "phaser3-rex-plugins": "^1.80.20",
     "regenerator-runtime": "^0.14.1"
   }


### PR DESCRIPTION
## Summary

Hotfix on top of #7. The bulk npm upgrade bumped `phaser` to 4.0.0, which broke both the build and runtime:

- **Build**: esbuild failed with `No matching export in phaser.esm.js for import 'default'` on every `import Phaser from 'phaser'` — Phaser 4 removed the default ESM export.
- **Runtime** (after working around the build): `phaser3-rex-plugins` logs `Can't supported version : 4` and throws `Cannot read properties of undefined (reading 'mixin')`. The plugin has no Phaser 4 port.

Since `phaser3-rex-plugins` is Phaser-3 only and is required by the game UI, the only safe path is to **pin phaser back to ^3.90.0** (latest Phaser 3 minor) while keeping every other upgrade from #7.

## Changes

- `package.json`: `phaser` `^4.0.0` → `^3.90.0`
- `jest.config.js`: mock `phaser3spectorjs` (transitive optional peer of Phaser 3's `WebGLRenderer` that isn't in the dep tree and isn't needed under jsdom)
- `package-lock.json`: regenerated

## Verification

- `npm test` → 10/10 suites, 17/17 tests pass
- `npm run build` → completes without errors, produces minified `dist/`
- Served `dist/` locally on :8072 → game boots, "Cosmos Wars" title screen renders, sprites + sound toggles visible, no console errors

## Follow-up

When `phaser3-rex-plugins` (or a fork) adds Phaser 4 support, Phaser can be revisited.