### PR TITLE
feat: 3D Three.js rewrite + optional 2-player WebRTC co-op + UI polish & procedural music

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,10 @@
 module.exports = {
-  testEnvironment: 'jsdom',
-  setupFiles: ['./setupTests.js', 'jest-canvas-mock'],
-  setupFilesAfterEnv: [
-    'jest-expect-subclass',
-  ],
+  testEnvironment: "jsdom",
+  setupFiles: ["./setupTests.js", "jest-canvas-mock"],
+  setupFilesAfterEnv: ["jest-expect-subclass"],
   moduleNameMapper: {
-    '\\.(css|less|sass|scss)$': '<rootDir>/tests/mocks/styleMock.js',
-    '\\.(gif|ttf|eot|svg|png|mp3|ogg)$': '<rootDir>/tests/mocks/fileMock.js',
-    '^phaser3spectorjs$': '<rootDir>/tests/mocks/fileMock.js',
+    "\\.(css|less|sass|scss)$": "<rootDir>/tests/mocks/styleMock.js",
+    "\\.(gif|ttf|eot|svg|png|mp3|ogg)$": "<rootDir>/tests/mocks/fileMock.js",
+    "^phaser3spectorjs$": "<rootDir>/tests/mocks/fileMock.js",
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "peerjs": "^1.5.5",
         "phaser": "^3.90.0",
         "phaser3-rex-plugins": "^1.80.20",
-        "regenerator-runtime": "^0.14.1"
+        "regenerator-runtime": "^0.14.1",
+        "three": "^0.169.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -3896,6 +3898,15 @@
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -11660,6 +11671,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/peerjs": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.5.tgz",
+      "integrity": "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^2.8.0",
+        "eventemitter3": "^4.0.7",
+        "peerjs-js-binarypack": "^2.1.0",
+        "webrtc-adapter": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs-js-binarypack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
+      "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/phaser": {
       "version": "3.90.0",
       "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
@@ -12388,6 +12437,12 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
     },
     "node_modules/serve": {
       "version": "14.2.6",
@@ -13250,6 +13305,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
+      "license": "MIT"
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -13759,6 +13820,19 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
+      "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,10 @@
     "unsplash-js": "^7.0.20"
   },
   "dependencies": {
+    "peerjs": "^1.5.5",
     "phaser": "^3.90.0",
     "phaser3-rex-plugins": "^1.80.20",
-    "regenerator-runtime": "^0.14.1"
+    "regenerator-runtime": "^0.14.1",
+    "three": "^0.169.0"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,10 +3,28 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>JS Shooter Game</title>
+    <title>Cosmos Wars — JS Shooter</title>
     <link rel="stylesheet" href="./index.css">
 </head>
 <body>
+    <div class="stage">
+        <header class="topbar">
+            <h1 class="brand">
+                <span class="brand-glyph">◢◤</span>
+                Cosmos&nbsp;Wars
+            </h1>
+            <p class="tagline">Defend the rim. Score for the leaderboard.</p>
+        </header>
+
+        <main class="game-frame">
+            <div id="phaser-game" class="game-canvas"></div>
+        </main>
+
+        <footer class="bottombar">
+            <span class="hint">Move: arrow keys / drag &nbsp;·&nbsp; Fire: auto</span>
+            <span class="version">v2.0 · Phaser 3 · esbuild</span>
+        </footer>
+    </div>
     <script src="./index.js"></script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -1,30 +1,53 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cosmos Wars — JS Shooter</title>
-    <link rel="stylesheet" href="./index.css">
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cosmos Wars 3D — JS Shooter</title>
+    <link rel="stylesheet" href="./index.css" />
+  </head>
+  <body>
     <div class="stage">
-        <header class="topbar">
-            <h1 class="brand">
-                <span class="brand-glyph">◢◤</span>
-                Cosmos&nbsp;Wars
-            </h1>
-            <p class="tagline">Defend the rim. Score for the leaderboard.</p>
-        </header>
+      <header class="topbar">
+        <h1 class="brand">
+          <span class="brand-glyph">◢◤</span>
+          Cosmos&nbsp;Wars
+          <span class="brand-tag">3D</span>
+        </h1>
+        <p class="tagline">A WebGL space shooter — defend the rim.</p>
+      </header>
 
-        <main class="game-frame">
-            <div id="phaser-game" class="game-canvas"></div>
-        </main>
+      <main class="game-frame">
+        <div id="phaser-game" class="game-canvas">
+          <div id="hud-overlay">
+            <div class="hud-top">
+              <div class="hud-cell">
+                <span class="hud-label">SCORE</span>
+                <span class="hud-value" id="hud-score">000000</span>
+              </div>
+              <div class="hud-cell hud-cell-center">
+                <span class="hud-value" id="hud-wave">WAVE 1</span>
+              </div>
+              <div class="hud-cell hud-cell-right">
+                <span class="hud-label">LIVES</span>
+                <span class="hud-value hud-lives" id="hud-lives">♥♥♥</span>
+              </div>
+            </div>
 
-        <footer class="bottombar">
-            <span class="hint">Move: arrow keys / drag &nbsp;·&nbsp; Fire: auto</span>
-            <span class="version">v2.0 · Phaser 3 · esbuild</span>
-        </footer>
+            <div class="hud-power" id="hud-power"></div>
+            <div class="hud-net" id="hud-net"></div>
+            <div class="hud-toast" id="hud-toast"></div>
+
+            <div class="hud-banner" id="hud-banner"></div>
+          </div>
+        </div>
+      </main>
+
+      <footer class="bottombar">
+        <span class="hint">Move: WASD / arrows / drag &nbsp;·&nbsp; Fire: Space / hold mouse</span>
+        <span class="version">v4.0 · Three.js · WebRTC co-op</span>
+      </footer>
     </div>
     <script src="./index.js"></script>
-</body>
+  </body>
 </html>

--- a/src/js/classes/ui/flatButton.js
+++ b/src/js/classes/ui/flatButton.js
@@ -1,6 +1,6 @@
-import Phaser from 'phaser';
-import EventEmitter from '../util/eventEmitter';
-import Model from '../modelAndController/model';
+import Phaser from "phaser";
+import EventEmitter from "../util/eventEmitter";
+import Model from "../modelAndController/model";
 
 class FlatButton extends Phaser.GameObjects.Container {
   constructor(config) {
@@ -36,12 +36,12 @@ class FlatButton extends Phaser.GameObjects.Container {
     this.scene.add.existing(this);
     if (config.event) {
       this.back.setInteractive({ useHandCursor: true });
-      this.back.on('pointerdown', this.pressed, this);
+      this.back.on("pointerdown", this.pressed, this);
     }
 
     if (Model.isMobile === -1) {
-      this.back.on('pointerover', this.over, this);
-      this.back.on('pointerout', this.out, this);
+      this.back.on("pointerover", this.over, this);
+      this.back.on("pointerout", this.out, this);
     }
   }
 
@@ -51,7 +51,7 @@ class FlatButton extends Phaser.GameObjects.Container {
       targets: this,
       scale: 1.08,
       duration: 140,
-      ease: 'Sine.easeOut',
+      ease: "Sine.easeOut",
     });
     if (this.back && this.back.setTint) {
       this.back.setTint(0xbfefff);
@@ -64,7 +64,7 @@ class FlatButton extends Phaser.GameObjects.Container {
       targets: this,
       scale: 1,
       duration: 140,
-      ease: 'Sine.easeOut',
+      ease: "Sine.easeOut",
     });
     if (this.back && this.back.clearTint) {
       this.back.clearTint();
@@ -78,7 +78,7 @@ class FlatButton extends Phaser.GameObjects.Container {
         scale: 0.94,
         yoyo: true,
         duration: 90,
-        ease: 'Quad.easeOut',
+        ease: "Quad.easeOut",
       });
     }
     if (this.config.params) {

--- a/src/js/classes/ui/flatButton.js
+++ b/src/js/classes/ui/flatButton.js
@@ -35,7 +35,7 @@ class FlatButton extends Phaser.GameObjects.Container {
 
     this.scene.add.existing(this);
     if (config.event) {
-      this.back.setInteractive();
+      this.back.setInteractive({ useHandCursor: true });
       this.back.on('pointerdown', this.pressed, this);
     }
 
@@ -46,14 +46,41 @@ class FlatButton extends Phaser.GameObjects.Container {
   }
 
   over() {
-    this.y -= 5;
+    if (this.hoverTween) this.hoverTween.stop();
+    this.hoverTween = this.scene.tweens.add({
+      targets: this,
+      scale: 1.08,
+      duration: 140,
+      ease: 'Sine.easeOut',
+    });
+    if (this.back && this.back.setTint) {
+      this.back.setTint(0xbfefff);
+    }
   }
 
   out() {
-    this.y += 5;
+    if (this.hoverTween) this.hoverTween.stop();
+    this.hoverTween = this.scene.tweens.add({
+      targets: this,
+      scale: 1,
+      duration: 140,
+      ease: 'Sine.easeOut',
+    });
+    if (this.back && this.back.clearTint) {
+      this.back.clearTint();
+    }
   }
 
   pressed() {
+    if (this.scene && this.scene.tweens) {
+      this.scene.tweens.add({
+        targets: this,
+        scale: 0.94,
+        yoyo: true,
+        duration: 90,
+        ease: 'Quad.easeOut',
+      });
+    }
     if (this.config.params) {
       EventEmitter.emit(this.config.event, this.config.params);
     } else {

--- a/src/js/classes/util/mediaManager.js
+++ b/src/js/classes/util/mediaManager.js
@@ -1,7 +1,7 @@
-import Model from '../modelAndController/model';
-import EventEmitter from './eventEmitter';
-import Constants from '../../constants';
-import { getSpaceMusic } from './spaceMusic';
+import Model from "../modelAndController/model";
+import EventEmitter from "./eventEmitter";
+import Constants from "../../constants";
+import { getSpaceMusic } from "./spaceMusic";
 
 class MediaManager {
   constructor(config) {

--- a/src/js/classes/util/mediaManager.js
+++ b/src/js/classes/util/mediaManager.js
@@ -1,22 +1,22 @@
 import Model from '../modelAndController/model';
 import EventEmitter from './eventEmitter';
 import Constants from '../../constants';
+import { getSpaceMusic } from './spaceMusic';
 
 class MediaManager {
   constructor(config) {
     this.scene = config.scene;
+    this.music = getSpaceMusic();
 
     EventEmitter.on(Constants.PLAY_SOUND, this.playSound, this);
     EventEmitter.on(Constants.MUSIC_CHANGED, this.musicChanged, this);
   }
 
   musicChanged() {
-    if (this.background) {
-      if (Model.musicOn === false) {
-        this.background.stop();
-      } else {
-        this.background.play();
-      }
+    if (Model.musicOn === false) {
+      this.music.stop();
+    } else {
+      this.music.start();
     }
   }
 
@@ -27,16 +27,11 @@ class MediaManager {
     }
   }
 
-  setBackgroundMusic(key) {
+  // Kept for API compatibility; the `key` is ignored because background
+  // music is now generated procedurally by SpaceMusic.
+  setBackgroundMusic() {
     if (Model.musicOn) {
-      this.background = this.scene.sound.add(
-        key,
-        {
-          volume: 0.5,
-          loop: true,
-        },
-      );
-      this.background.play();
+      this.music.start();
     }
   }
 }

--- a/src/js/classes/util/spaceMusic.js
+++ b/src/js/classes/util/spaceMusic.js
@@ -9,15 +9,15 @@
 const PROGRESSION = [
   // [root semitones from A4=0, chord intervals]
   { root: -12, intervals: [0, 7, 12, 15] }, // Am
-  { root: -7,  intervals: [0, 7, 12, 16] }, // F  (relative)
-  { root: -5,  intervals: [0, 7, 12, 16] }, // C
-  { root: -3,  intervals: [0, 7, 12, 15] }, // Dm
+  { root: -7, intervals: [0, 7, 12, 16] }, // F  (relative)
+  { root: -5, intervals: [0, 7, 12, 16] }, // C
+  { root: -3, intervals: [0, 7, 12, 15] }, // Dm
 ];
 
 const ARP_PATTERN = [0, 2, 1, 3, 1, 2];
 
 const A4 = 440;
-const semitone = (n) => A4 * (2 ** (n / 12));
+const semitone = (n) => A4 * 2 ** (n / 12);
 
 class SpaceMusic {
   constructor() {
@@ -41,10 +41,13 @@ class SpaceMusic {
   start() {
     this.ensureContext();
     if (!this.ctx || this.playing) return;
-    if (this.ctx.state === 'suspended') this.ctx.resume();
+    if (this.ctx.state === "suspended") this.ctx.resume();
     this.playing = true;
     this.master.gain.cancelScheduledValues(this.ctx.currentTime);
-    this.master.gain.linearRampToValueAtTime(this.volume, this.ctx.currentTime + 1.2);
+    this.master.gain.linearRampToValueAtTime(
+      this.volume,
+      this.ctx.currentTime + 1.2,
+    );
 
     const beat = 0.5; // seconds per arp note
     const barNotes = ARP_PATTERN.length;
@@ -81,7 +84,7 @@ class SpaceMusic {
     chord.intervals.forEach((iv) => {
       const freq = semitone(chord.root + iv);
       this.voice({
-        type: 'sawtooth',
+        type: "sawtooth",
         freq,
         startTime,
         duration: duration + 0.4,
@@ -91,7 +94,7 @@ class SpaceMusic {
         filterFreq: 1200,
       });
       this.voice({
-        type: 'sine',
+        type: "sine",
         freq: freq * 2,
         startTime,
         duration: duration + 0.4,
@@ -108,7 +111,7 @@ class SpaceMusic {
       const interval = chord.intervals[step % chord.intervals.length];
       const freq = semitone(chord.root + interval + 12); // up an octave
       this.voice({
-        type: 'triangle',
+        type: "triangle",
         freq,
         startTime: startTime + i * beat,
         duration: beat * 0.9,
@@ -123,7 +126,7 @@ class SpaceMusic {
   scheduleBass(startTime, duration, chord) {
     const freq = semitone(chord.root - 12);
     this.voice({
-      type: 'sine',
+      type: "sine",
       freq,
       startTime,
       duration: duration + 0.2,
@@ -134,12 +137,21 @@ class SpaceMusic {
     });
   }
 
-  voice({ type, freq, startTime, duration, attack, release, peak, filterFreq }) {
+  voice({
+    type,
+    freq,
+    startTime,
+    duration,
+    attack,
+    release,
+    peak,
+    filterFreq,
+  }) {
     if (!this.ctx) return;
     const osc = this.ctx.createOscillator();
     const gain = this.ctx.createGain();
     const filter = this.ctx.createBiquadFilter();
-    filter.type = 'lowpass';
+    filter.type = "lowpass";
     filter.frequency.value = filterFreq;
     osc.type = type;
     osc.frequency.value = freq;

--- a/src/js/classes/util/spaceMusic.js
+++ b/src/js/classes/util/spaceMusic.js
@@ -1,0 +1,170 @@
+/**
+ * Procedural space-ambient music synthesizer.
+ *
+ * Generates a looping background track at runtime using the Web Audio API,
+ * so we don't need to ship a music binary. The track is a slow chord pad
+ * with an arpeggiated lead over a 4-chord progression in A minor.
+ */
+
+const PROGRESSION = [
+  // [root semitones from A4=0, chord intervals]
+  { root: -12, intervals: [0, 7, 12, 15] }, // Am
+  { root: -7,  intervals: [0, 7, 12, 16] }, // F  (relative)
+  { root: -5,  intervals: [0, 7, 12, 16] }, // C
+  { root: -3,  intervals: [0, 7, 12, 15] }, // Dm
+];
+
+const ARP_PATTERN = [0, 2, 1, 3, 1, 2];
+
+const A4 = 440;
+const semitone = (n) => A4 * (2 ** (n / 12));
+
+class SpaceMusic {
+  constructor() {
+    this.ctx = null;
+    this.master = null;
+    this.timer = null;
+    this.playing = false;
+    this.volume = 0.18;
+  }
+
+  ensureContext() {
+    if (this.ctx) return;
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    if (!Ctx) return;
+    this.ctx = new Ctx();
+    this.master = this.ctx.createGain();
+    this.master.gain.value = 0;
+    this.master.connect(this.ctx.destination);
+  }
+
+  start() {
+    this.ensureContext();
+    if (!this.ctx || this.playing) return;
+    if (this.ctx.state === 'suspended') this.ctx.resume();
+    this.playing = true;
+    this.master.gain.cancelScheduledValues(this.ctx.currentTime);
+    this.master.gain.linearRampToValueAtTime(this.volume, this.ctx.currentTime + 1.2);
+
+    const beat = 0.5; // seconds per arp note
+    const barNotes = ARP_PATTERN.length;
+    const barDuration = beat * barNotes;
+    let chordIndex = 0;
+
+    const scheduleBar = () => {
+      if (!this.playing || !this.ctx) return;
+      const now = this.ctx.currentTime;
+      const chord = PROGRESSION[chordIndex % PROGRESSION.length];
+      this.scheduleChordPad(now, barDuration, chord);
+      this.scheduleArp(now, beat, chord);
+      this.scheduleBass(now, barDuration, chord);
+      chordIndex += 1;
+    };
+
+    scheduleBar();
+    this.timer = window.setInterval(scheduleBar, barDuration * 1000);
+  }
+
+  stop() {
+    if (!this.ctx || !this.playing) return;
+    this.playing = false;
+    if (this.timer) {
+      window.clearInterval(this.timer);
+      this.timer = null;
+    }
+    const now = this.ctx.currentTime;
+    this.master.gain.cancelScheduledValues(now);
+    this.master.gain.linearRampToValueAtTime(0, now + 0.4);
+  }
+
+  scheduleChordPad(startTime, duration, chord) {
+    chord.intervals.forEach((iv) => {
+      const freq = semitone(chord.root + iv);
+      this.voice({
+        type: 'sawtooth',
+        freq,
+        startTime,
+        duration: duration + 0.4,
+        attack: 0.6,
+        release: 0.8,
+        peak: 0.06,
+        filterFreq: 1200,
+      });
+      this.voice({
+        type: 'sine',
+        freq: freq * 2,
+        startTime,
+        duration: duration + 0.4,
+        attack: 0.8,
+        release: 0.8,
+        peak: 0.04,
+        filterFreq: 2400,
+      });
+    });
+  }
+
+  scheduleArp(startTime, beat, chord) {
+    ARP_PATTERN.forEach((step, i) => {
+      const interval = chord.intervals[step % chord.intervals.length];
+      const freq = semitone(chord.root + interval + 12); // up an octave
+      this.voice({
+        type: 'triangle',
+        freq,
+        startTime: startTime + i * beat,
+        duration: beat * 0.9,
+        attack: 0.01,
+        release: 0.25,
+        peak: 0.09,
+        filterFreq: 3500,
+      });
+    });
+  }
+
+  scheduleBass(startTime, duration, chord) {
+    const freq = semitone(chord.root - 12);
+    this.voice({
+      type: 'sine',
+      freq,
+      startTime,
+      duration: duration + 0.2,
+      attack: 0.05,
+      release: 0.4,
+      peak: 0.18,
+      filterFreq: 600,
+    });
+  }
+
+  voice({ type, freq, startTime, duration, attack, release, peak, filterFreq }) {
+    if (!this.ctx) return;
+    const osc = this.ctx.createOscillator();
+    const gain = this.ctx.createGain();
+    const filter = this.ctx.createBiquadFilter();
+    filter.type = 'lowpass';
+    filter.frequency.value = filterFreq;
+    osc.type = type;
+    osc.frequency.value = freq;
+
+    const t0 = startTime;
+    const tEnd = startTime + duration;
+    gain.gain.setValueAtTime(0, t0);
+    gain.gain.linearRampToValueAtTime(peak, t0 + attack);
+    gain.gain.setValueAtTime(peak, Math.max(t0 + attack, tEnd - release));
+    gain.gain.linearRampToValueAtTime(0, tEnd);
+
+    osc.connect(filter);
+    filter.connect(gain);
+    gain.connect(this.master);
+
+    osc.start(t0);
+    osc.stop(tEnd + 0.05);
+  }
+}
+
+// Shared across scene transitions so the loop doesn't restart.
+let shared = null;
+export function getSpaceMusic() {
+  if (!shared) shared = new SpaceMusic();
+  return shared;
+}
+
+export default SpaceMusic;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-import Game from './game';
-import '../styles/style.css';
+import Game from "./game";
+import "../styles/style.css";
 
 window.game = new Game();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,5 @@
-import Game from "./game";
+import ThreeGame from "./three3d/game";
 import "../styles/style.css";
 
-window.game = new Game();
+const container = document.getElementById("phaser-game");
+window.game = new ThreeGame(container);

--- a/src/js/three3d/game.js
+++ b/src/js/three3d/game.js
@@ -1,0 +1,1014 @@
+import * as THREE from "three";
+import {
+  createPlayerShip,
+  createPlayer2Ship,
+  createEnemyShip,
+  createBullet,
+  createAsteroid,
+  createPowerup,
+  createBoss,
+} from "./models";
+import { createStarfield } from "./starfield";
+import Hud from "./hud";
+import { getSpaceMusic } from "../classes/util/spaceMusic";
+import { NetHost, NetClient } from "./net";
+
+const FIELD_X = 18;
+const FIELD_Y = 11;
+const SPAWN_Z = -120;
+const KILL_Z = 12;
+
+// ---------- helpers ----------
+const _v = new THREE.Vector3();
+function distSq2D(a, b) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return dx * dx + dy * dy + dz * dz;
+}
+function shareUrlForCode(code) {
+  const u = new URL(window.location.href);
+  u.searchParams.set("join", code);
+  u.hash = "";
+  return u.toString();
+}
+function readJoinFromUrl() {
+  const u = new URL(window.location.href);
+  return (u.searchParams.get("join") || "").toUpperCase();
+}
+
+// ---------- Game ----------
+class ThreeGame {
+  constructor(container) {
+    this.container = container;
+    this.width = container.clientWidth;
+    this.height = container.clientHeight || this.width * 0.6;
+
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.PerspectiveCamera(
+      62,
+      this.width / this.height,
+      0.1,
+      2000,
+    );
+    this.camera.position.set(0, 2.5, 8);
+    this.camera.lookAt(0, 0, -10);
+    this.cameraShake = 0;
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.setSize(this.width, this.height);
+    this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this.renderer.toneMappingExposure = 1.1;
+    container.appendChild(this.renderer.domElement);
+
+    // Lighting
+    this.scene.add(new THREE.AmbientLight(0x445577, 0.6));
+    const key = new THREE.DirectionalLight(0xffeec8, 1.0);
+    key.position.set(5, 8, 6);
+    this.scene.add(key);
+    const rim = new THREE.DirectionalLight(0x66aaff, 0.7);
+    rim.position.set(-6, -3, -8);
+    this.scene.add(rim);
+
+    createStarfield(this.scene);
+
+    // Player ships (created up-front; visibility toggled by mode)
+    this.player = createPlayerShip();
+    this.player.position.set(0, 0, 2);
+    this.scene.add(this.player);
+    this.player2 = createPlayer2Ship();
+    this.player2.position.set(3, 0, 2);
+    this.player2.visible = false;
+    this.scene.add(this.player2);
+
+    // Game state
+    this.bullets = [];
+    this.enemies = [];
+    this.asteroids = [];
+    this.particles = [];
+    this.powerups = [];
+    this.boss = null;
+    this.score = 0;
+    this.lives = 3;
+    this.wave = 1;
+    this.fireCooldown = 0;
+    this.fireCooldown2 = 0;
+    this.spawnCooldown = 0;
+    this.bossSpawnedForWave = 0;
+    this.invuln = 0;
+    this.invuln2 = 0;
+    this.shield1 = 0;
+    this.shield2 = 0;
+    this.power1 = null; // {kind, until}
+    this.power2 = null;
+    this.running = false;
+    this.gameOver = false;
+    this.entId = 1;
+    this.netRole = "solo"; // 'solo' | 'host' | 'client'
+    this.net = null;
+    this.netSnapTimer = 0;
+    this.netInputTimer = 0;
+    this.lastSnap = null; // for client interpolation
+    this.remoteIn = { x: 0, y: 0, fire: false, dragging: false };
+
+    this.input = {
+      x: 0,
+      y: 0,
+      fire: false,
+      dragging: false,
+      dragX: 0,
+      dragY: 0,
+    };
+
+    this.hud = new Hud();
+    this.music = getSpaceMusic();
+
+    this.bindInput();
+    window.addEventListener("resize", () => this.onResize());
+    if (typeof ResizeObserver !== "undefined") {
+      this.ro = new ResizeObserver(() => this.onResize());
+      this.ro.observe(container);
+    }
+
+    this.clock = new THREE.Clock();
+    this.renderer.setAnimationLoop(() => this.tick());
+    requestAnimationFrame(() => this.onResize());
+
+    this.hud.setScore(0);
+    this.hud.setLives(this.lives);
+    this.hud.setWave(this.wave);
+    this.openMenu();
+  }
+
+  // ---------- Menu / mode selection ----------
+  openMenu() {
+    // Pause the world while we're in menus so leftover entities can't keep
+    // hitting the (forgotten) player from a previous run.
+    this.running = false;
+    // Reset visible HUD counters so a stale "lives = 1" doesn't confuse the
+    // player while they're choosing the next mode.
+    this.hud.setScore(0);
+    this.hud.setLives(3);
+    this.hud.setWave(1);
+    this.hud.setPower(null);
+    this.hud.setNetStatus("");
+    const prefill = readJoinFromUrl();
+    if (prefill) {
+      this.openJoin(prefill);
+      return;
+    }
+    this.hud.showMenu({
+      onSolo: () => this.startSolo(),
+      onHost: () => this.openHost(),
+      onJoin: () => this.openJoin(),
+    });
+  }
+
+  openHost() {
+    this.running = false;
+    this.netRole = "host";
+    if (this.net) this.net.destroy();
+    this.net = new NetHost();
+    const showLobby = () => {
+      const url = shareUrlForCode(this.net.code);
+      this.hud.showHostLobby({
+        code: this.net.code,
+        shareUrl: url,
+        onCancel: () => {
+          this.net.destroy();
+          this.net = null;
+          this.netRole = "solo";
+          this.openMenu();
+        },
+        onStart: () => {
+          this.net.send({ t: "go" });
+          this.startMultiplayer();
+        },
+      });
+    };
+    showLobby();
+    this.net.onStatus = (s) => this.hud.showToast(s, 1800);
+    this.net.onOpen = () => this.hud.setLobbyConnected(true);
+    this.net.onClose = () => this.hud.setLobbyConnected(false);
+    this.net.onMessage = (msg) => this.handleNetMessage(msg);
+  }
+
+  openJoin(prefill) {
+    this.running = false;
+    this.netRole = "client";
+    this.hud.showJoinForm({
+      prefillCode: prefill,
+      onCancel: () => {
+        if (this.net) {
+          this.net.destroy();
+          this.net = null;
+        }
+        this.netRole = "solo";
+        this.openMenu();
+      },
+      onJoin: (code) => {
+        if (this.net) this.net.destroy();
+        this.net = new NetClient(code);
+        this.net.onStatus = (s) => this.hud.setJoinStatus(s);
+        this.net.onMessage = (msg) => this.handleNetMessage(msg);
+        this.net.onOpen = () =>
+          this.hud.setJoinStatus("Connected. Waiting for host to launch…");
+        this.net.onClose = () =>
+          this.hud.setJoinStatus("Disconnected from host.");
+      },
+    });
+    if (prefill) {
+      // auto-submit
+      setTimeout(() => {
+        const btn = document.getElementById("hud-join-go");
+        if (btn) btn.click();
+      }, 50);
+    }
+  }
+
+  // ---------- Lifecycle ----------
+  startSolo() {
+    this.netRole = "solo";
+    if (this.net) {
+      this.net.destroy();
+      this.net = null;
+    }
+    this.player2.visible = false;
+    this.hud.setNetStatus("");
+    this._beginRun();
+  }
+
+  startMultiplayer() {
+    this.player2.visible = true;
+    this.hud.setNetStatus(this.netRole === "host" ? "CO-OP · HOST" : "CO-OP · CLIENT");
+    this._beginRun();
+  }
+
+  _beginRun() {
+    this.reset();
+    this.running = true;
+    this.gameOver = false;
+    this.invuln = 2.0;
+    this.invuln2 = 2.0;
+    this.spawnCooldown = 1.4;
+    this.music.start();
+    this.hud.hideBanner();
+  }
+
+  reset() {
+    [...this.bullets, ...this.enemies, ...this.asteroids, ...this.particles, ...this.powerups]
+      .forEach((o) => this.scene.remove(o.mesh));
+    if (this.boss) {
+      this.scene.remove(this.boss.mesh);
+      this.boss = null;
+    }
+    this.bullets = [];
+    this.enemies = [];
+    this.asteroids = [];
+    this.particles = [];
+    this.powerups = [];
+    this.score = 0;
+    this.lives = 3;
+    this.wave = 1;
+    this.bossSpawnedForWave = 0;
+    this.invuln = 0;
+    this.invuln2 = 0;
+    this.shield1 = 0;
+    this.shield2 = 0;
+    this.power1 = null;
+    this.power2 = null;
+    this.gameOver = false;
+    this.player.position.set(this.netRole === "solo" ? 0 : -2, 0, 2);
+    this.player.visible = true;
+    this.player2.position.set(2, 0, 2);
+    this.player2.visible = this.netRole !== "solo";
+    this.hud.setScore(0);
+    this.hud.setLives(this.lives);
+    this.hud.setWave(this.wave);
+    this.hud.setPower(null);
+  }
+
+  // ---------- Input ----------
+  bindInput() {
+    const keys = {};
+    window.addEventListener("keydown", (e) => {
+      keys[e.code] = true;
+      if (e.code === "Space") e.preventDefault();
+    });
+    window.addEventListener("keyup", (e) => {
+      keys[e.code] = false;
+    });
+
+    this.tickInput = () => {
+      let x = 0;
+      let y = 0;
+      if (keys.ArrowLeft || keys.KeyA) x -= 1;
+      if (keys.ArrowRight || keys.KeyD) x += 1;
+      if (keys.ArrowUp || keys.KeyW) y += 1;
+      if (keys.ArrowDown || keys.KeyS) y -= 1;
+      this.input.x = x;
+      this.input.y = y;
+      this.input.fire = !!keys.Space || this.input.dragging;
+    };
+
+    const canvas = this.renderer.domElement;
+    canvas.style.touchAction = "none";
+    const setDrag = (cx, cy) => {
+      const r = canvas.getBoundingClientRect();
+      const nx = ((cx - r.left) / r.width) * 2 - 1;
+      const ny = -(((cy - r.top) / r.height) * 2 - 1);
+      this.input.dragX = nx * FIELD_X;
+      this.input.dragY = ny * FIELD_Y;
+    };
+    canvas.addEventListener("pointerdown", (e) => {
+      this.input.dragging = true;
+      try { canvas.setPointerCapture(e.pointerId); } catch (_) {/* ignore */}
+      setDrag(e.clientX, e.clientY);
+    });
+    canvas.addEventListener("pointermove", (e) => {
+      if (this.input.dragging) setDrag(e.clientX, e.clientY);
+    });
+    const endDrag = () => { this.input.dragging = false; };
+    canvas.addEventListener("pointerup", endDrag);
+    canvas.addEventListener("pointercancel", endDrag);
+  }
+
+  // ---------- Networking ----------
+  handleNetMessage(msg) {
+    if (!msg || !msg.t) return;
+    if (this.netRole === "host") {
+      if (msg.t === "in") {
+        this.remoteIn = msg;
+      }
+    } else if (this.netRole === "client") {
+      if (msg.t === "go") {
+        this.startMultiplayer();
+      } else if (msg.t === "snap") {
+        this.applySnapshot(msg);
+      } else if (msg.t === "fx") {
+        // small fx event: burst at position
+        this.spawnBurst({ x: msg.x, y: msg.y, z: msg.z }, msg.c || 0xff8844, msg.n || 16);
+        if (msg.shake) this.cameraShake = Math.max(this.cameraShake, msg.shake);
+      } else if (msg.t === "over") {
+        this.gameOver = true;
+        this.running = false;
+        this.hud.showBanner("GAME OVER", `Final score: ${msg.score}`,
+          "BACK TO MENU", () => this.openMenu());
+      }
+    }
+  }
+
+  /** Build snapshot for transmission to client. Lightweight. */
+  buildSnapshot() {
+    const enc = (e, type) => ({
+      id: e.id, t: type,
+      x: +e.mesh.position.x.toFixed(2),
+      y: +e.mesh.position.y.toFixed(2),
+      z: +e.mesh.position.z.toFixed(2),
+      r: e.radius || 0,
+    });
+    return {
+      t: "snap",
+      p1: { x: +this.player.position.x.toFixed(2), y: +this.player.position.y.toFixed(2), v: this.player.visible, i: this.invuln > 0 },
+      p2: { x: +this.player2.position.x.toFixed(2), y: +this.player2.position.y.toFixed(2), v: this.player2.visible, i: this.invuln2 > 0 },
+      bs: this.bullets.map((b) => ({
+        id: b.id, x: +b.mesh.position.x.toFixed(2), y: +b.mesh.position.y.toFixed(2), z: +b.mesh.position.z.toFixed(2),
+        f: b.friendly ? 1 : 0,
+      })),
+      es: this.enemies.map((e) => enc(e, "e")),
+      as: this.asteroids.map((a) => enc(a, "a")),
+      ps: this.powerups.map((p) => ({ id: p.id, k: p.kind,
+        x: +p.mesh.position.x.toFixed(2), y: +p.mesh.position.y.toFixed(2), z: +p.mesh.position.z.toFixed(2) })),
+      bo: this.boss ? { x: +this.boss.mesh.position.x.toFixed(2), y: +this.boss.mesh.position.y.toFixed(2), z: +this.boss.mesh.position.z.toFixed(2), hp: this.boss.hp } : null,
+      sc: this.score, lv: this.lives, wv: this.wave,
+      pw1: this.power1 ? this.power1.kind : null,
+      pw2: this.power2 ? this.power2.kind : null,
+      sh1: this.shield1, sh2: this.shield2,
+    };
+  }
+
+  /** Apply received snapshot on client by reconciling local mesh pool. */
+  applySnapshot(s) {
+    if (!this.running) {
+      this.running = true;
+      this.player2.visible = true;
+      this.hud.hideBanner();
+      this.hud.setNetStatus("CO-OP · CLIENT");
+    }
+    this.lastSnap = s;
+    // Players
+    this.player.position.set(s.p1.x, s.p1.y, 2);
+    this.player.visible = s.p1.v && !(s.p1.i && Math.floor(performance.now()/70)%2);
+    this.player2.position.set(s.p2.x, s.p2.y, 2);
+    this.player2.visible = s.p2.v && !(s.p2.i && Math.floor(performance.now()/70)%2);
+    // HUD
+    this.score = s.sc; this.lives = s.lv; this.wave = s.wv;
+    this.hud.setScore(s.sc); this.hud.setLives(s.lv); this.hud.setWave(s.wv);
+    const power = this.netRole === "client" ? s.pw2 : s.pw1;
+    const shield = this.netRole === "client" ? s.sh2 : s.sh1;
+    this._updatePowerHud(power, shield);
+    // Reconcile entity pools
+    this._reconcilePool(this.bullets, s.bs, (item) => {
+      const c = item.f ? 0x66e0ff : 0xff5ed1;
+      const m = createBullet(c);
+      this.scene.add(m);
+      return { mesh: m, id: item.id, friendly: !!item.f };
+    });
+    this._reconcilePool(this.enemies, s.es, (item) => {
+      const m = createEnemyShip();
+      this.scene.add(m);
+      return { mesh: m, id: item.id };
+    });
+    this._reconcilePool(this.asteroids, s.as, (item) => {
+      const r = item.r || 0.8;
+      const m = createAsteroid(r);
+      this.scene.add(m);
+      return { mesh: m, id: item.id, radius: r };
+    });
+    this._reconcilePool(this.powerups, s.ps, (item) => {
+      const m = createPowerup(item.k);
+      this.scene.add(m);
+      return { mesh: m, id: item.id, kind: item.k };
+    });
+    if (s.bo) {
+      if (!this.boss) {
+        const m = createBoss();
+        this.scene.add(m);
+        this.boss = { mesh: m, hp: s.bo.hp };
+      }
+      this.boss.mesh.position.set(s.bo.x, s.bo.y, s.bo.z);
+      this.boss.hp = s.bo.hp;
+    } else if (this.boss) {
+      this.scene.remove(this.boss.mesh);
+      this.boss = null;
+    }
+  }
+
+  _reconcilePool(localArr, remoteArr, makeFn) {
+    const seen = new Set();
+    for (const item of remoteArr) {
+      seen.add(item.id);
+      let local = localArr.find((l) => l.id === item.id);
+      if (!local) {
+        local = makeFn(item);
+        localArr.push(local);
+      }
+      local.mesh.position.set(item.x, item.y, item.z);
+    }
+    for (let i = localArr.length - 1; i >= 0; i -= 1) {
+      if (!seen.has(localArr[i].id)) {
+        this.scene.remove(localArr[i].mesh);
+        localArr.splice(i, 1);
+      }
+    }
+  }
+
+  _updatePowerHud(kind, shield) {
+    let label = "";
+    if (kind === "rapid") label = "⚡ RAPID FIRE";
+    else if (kind === "triple") label = "🔱 TRIPLE-SHOT";
+    if (shield > 0) label = (label ? label + " · " : "") + "🛡 SHIELD";
+    this.hud.setPower(label || null);
+  }
+
+  // ---------- Spawning ----------
+  spawnEnemy() {
+    const enemy = createEnemyShip();
+    enemy.position.set(
+      (Math.random() * 2 - 1) * FIELD_X * 0.85,
+      (Math.random() * 2 - 1) * FIELD_Y * 0.85,
+      SPAWN_Z,
+    );
+    this.scene.add(enemy);
+    this.enemies.push({
+      id: this.entId++,
+      mesh: enemy,
+      speed: 22 + this.wave * 2 + Math.random() * 6,
+      drift: new THREE.Vector2((Math.random() - 0.5) * 4, (Math.random() - 0.5) * 4),
+      hp: 1,
+      fireTimer: 1 + Math.random() * 2,
+    });
+  }
+
+  spawnAsteroid() {
+    const radius = 0.6 + Math.random() * 1.4;
+    const ast = createAsteroid(radius);
+    ast.position.set(
+      (Math.random() * 2 - 1) * FIELD_X,
+      (Math.random() * 2 - 1) * FIELD_Y,
+      SPAWN_Z,
+    );
+    this.scene.add(ast);
+    this.asteroids.push({
+      id: this.entId++,
+      mesh: ast,
+      speed: 18 + Math.random() * 10,
+      spin: new THREE.Vector3((Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2),
+      radius,
+    });
+  }
+
+  spawnBoss() {
+    const m = createBoss();
+    m.position.set(0, 0, SPAWN_Z * 0.6);
+    this.scene.add(m);
+    this.boss = {
+      mesh: m,
+      id: this.entId++,
+      hp: 12 + this.wave * 2,
+      speed: 6,
+      fireTimer: 1.5,
+      sweepT: 0,
+    };
+    this.hud.showToast(`⚠ MINI-BOSS — WAVE ${this.wave} ⚠`, 2200);
+  }
+
+  spawnPowerup(at) {
+    const kinds = ["rapid", "triple", "shield"];
+    const kind = kinds[Math.floor(Math.random() * kinds.length)];
+    const m = createPowerup(kind);
+    m.position.copy(at);
+    this.scene.add(m);
+    this.powerups.push({ id: this.entId++, mesh: m, kind, speed: 8 });
+  }
+
+  fireFrom(ship, owner) {
+    const power = owner === 1 ? this.power1 : this.power2;
+    const color = owner === 1 ? 0x66e0ff : 0xff5ed1;
+    const make = (offX, dir) => {
+      const b = createBullet(color);
+      b.position.copy(ship.position);
+      b.position.x += offX;
+      b.position.z -= 1.6;
+      this.scene.add(b);
+      const speed = 80;
+      const vel = new THREE.Vector3(dir * 8, 0, -speed);
+      this.bullets.push({ id: this.entId++, mesh: b, vel, friendly: true, owner });
+    };
+    if (power && power.kind === "triple") {
+      make(0, 0); make(-0.7, -0.8); make(0.7, 0.8);
+      make(-1.4, -1.6); make(1.4, 1.6);
+    } else {
+      make(0, 0); make(-1.0, 0); make(1.0, 0);
+    }
+  }
+
+  enemyFireFrom(srcMesh, targetMesh) {
+    const bullet = createBullet(0xff5ed1);
+    bullet.position.copy(srcMesh.position);
+    bullet.position.z += 1;
+    this.scene.add(bullet);
+    const dir = new THREE.Vector3()
+      .subVectors(targetMesh.position, srcMesh.position)
+      .normalize()
+      .multiplyScalar(45);
+    this.bullets.push({ id: this.entId++, mesh: bullet, vel: dir, friendly: false });
+  }
+
+  spawnBurst(position, color = 0xffaa66, count = 20) {
+    for (let i = 0; i < count; i += 1) {
+      const geo = new THREE.SphereGeometry(0.08 + Math.random() * 0.12, 6, 6);
+      const mat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 1 });
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.copy(position);
+      this.scene.add(mesh);
+      this.particles.push({
+        mesh,
+        vel: new THREE.Vector3((Math.random() - 0.5) * 14, (Math.random() - 0.5) * 14, (Math.random() - 0.5) * 14),
+        life: 0.6 + Math.random() * 0.4,
+      });
+    }
+  }
+
+  applyPower(owner, kind) {
+    const slot = owner === 1 ? "power1" : "power2";
+    const shieldSlot = owner === 1 ? "shield1" : "shield2";
+    if (kind === "shield") {
+      this[shieldSlot] = 1;
+    } else {
+      this[slot] = { kind, until: performance.now() / 1000 + 8 };
+    }
+    if ((owner === 1 && this.netRole !== "client") || (owner === 2 && this.netRole === "client")) {
+      this._updatePowerHud(kind === "shield" ? (this[slot] && this[slot].kind) : kind,
+                           this[shieldSlot]);
+      this.hud.showToast(`POWER-UP: ${kind.toUpperCase()}`);
+    }
+  }
+
+  // ---------- Main tick ----------
+  tick() {
+    const dt = Math.min(0.05, this.clock.getDelta());
+    this.tickInput();
+
+    // Animate decorative powerup rings/spin even on title
+    for (const p of this.powerups) {
+      p.mesh.rotation.y += dt * 1.6;
+      if (p.mesh.userData.ring) p.mesh.userData.ring.rotation.x += dt * 2.4;
+    }
+
+    if (this.netRole === "client") {
+      // Local control of own ship (client = player2). Send to host.
+      this.netInputTimer -= dt;
+      if (this.netInputTimer <= 0) {
+        this.netInputTimer = 1 / 30;
+        if (this.net && this.net.conn && this.net.conn.open) {
+          this.net.send({ t: "in", x: this.input.x, y: this.input.y,
+            fire: this.input.fire, dragging: this.input.dragging,
+            dragX: this.input.dragX, dragY: this.input.dragY });
+        }
+      }
+      // Move own ship locally for snappy feel (host will overwrite via snapshot)
+      this._movePlayerLocal(this.player2, this.input, dt);
+      this._renderFrame(dt);
+      return;
+    }
+
+    // SOLO or HOST: full simulation runs locally.
+    if (this.netRole === "host") {
+      // Apply remote input to player2
+      this._movePlayerLocal(this.player2, this.remoteIn, dt);
+      this.fireCooldown2 -= dt;
+      const rapid2 = this.power2 && this.power2.kind === "rapid";
+      if (this.remoteIn.fire && this.fireCooldown2 <= 0 && this.running && !this.gameOver) {
+        this.fireFrom(this.player2, 2);
+        this.fireCooldown2 = rapid2 ? 0.08 : 0.16;
+      }
+    }
+    this._movePlayerLocal(this.player, this.input, dt);
+
+    if (!this.running) {
+      this._renderFrame(dt);
+      return;
+    }
+
+    // Player 1 fire
+    this.fireCooldown -= dt;
+    const rapid1 = this.power1 && this.power1.kind === "rapid";
+    if (this.input.fire && this.fireCooldown <= 0 && !this.gameOver) {
+      this.fireFrom(this.player, 1);
+      this.fireCooldown = rapid1 ? 0.08 : 0.16;
+    }
+
+    // Power timers
+    const now = performance.now() / 1000;
+    if (this.power1 && this.power1.until < now) this.power1 = null;
+    if (this.power2 && this.power2.until < now) this.power2 = null;
+    this._updatePowerHud(
+      (this.netRole === "host" ? this.power1 : (this.power1 || this.power2))?.kind,
+      this.netRole === "host" ? this.shield1 : Math.max(this.shield1, this.shield2),
+    );
+
+    // Boss spawn check (every 3 waves, once per wave)
+    if (!this.boss && this.wave % 3 === 0 && this.bossSpawnedForWave !== this.wave) {
+      this.spawnBoss();
+      this.bossSpawnedForWave = this.wave;
+    }
+
+    // Regular spawning (paused while boss alive)
+    if (!this.boss) {
+      this.spawnCooldown -= dt;
+      if (this.spawnCooldown <= 0 && !this.gameOver) {
+        if (Math.random() < 0.65) this.spawnEnemy(); else this.spawnAsteroid();
+        this.spawnCooldown = Math.max(0.4, 1.5 - this.wave * 0.07);
+      }
+    }
+
+    // Bullets
+    for (let i = this.bullets.length - 1; i >= 0; i -= 1) {
+      const b = this.bullets[i];
+      if (b.vel) {
+        b.mesh.position.addScaledVector(b.vel, dt);
+        b.mesh.lookAt(_v.copy(b.mesh.position).add(b.vel));
+      }
+      const z = b.mesh.position.z;
+      if (z < SPAWN_Z - 5 || z > KILL_Z + 8 || Math.abs(b.mesh.position.x) > 50 || Math.abs(b.mesh.position.y) > 50) {
+        this.scene.remove(b.mesh);
+        this.bullets.splice(i, 1);
+      }
+    }
+
+    // Power-up drift
+    for (let i = this.powerups.length - 1; i >= 0; i -= 1) {
+      const p = this.powerups[i];
+      p.mesh.position.z += p.speed * dt;
+      // Pickup check (both players)
+      const players = [{ s: this.player, owner: 1 }];
+      if (this.netRole !== "solo") players.push({ s: this.player2, owner: 2 });
+      let picked = false;
+      for (const pl of players) {
+        if (distSq2D(p.mesh.position, pl.s.position) < 1.4 ** 2) {
+          this.applyPower(pl.owner, p.kind);
+          this.spawnBurst(p.mesh.position, 0xffffaa, 14);
+          picked = true;
+          break;
+        }
+      }
+      if (picked || p.mesh.position.z > KILL_Z) {
+        this.scene.remove(p.mesh);
+        this.powerups.splice(i, 1);
+      }
+    }
+
+    // Enemies
+    for (let i = this.enemies.length - 1; i >= 0; i -= 1) {
+      const e = this.enemies[i];
+      e.mesh.position.z += e.speed * dt;
+      e.mesh.position.x += e.drift.x * dt;
+      e.mesh.position.y += e.drift.y * dt;
+      e.mesh.rotation.z += dt * 1.2;
+
+      e.fireTimer -= dt;
+      if (e.fireTimer <= 0 && e.mesh.position.z < -10) {
+        const target = (this.netRole !== "solo" && Math.random() < 0.5) ? this.player2 : this.player;
+        this.enemyFireFrom(e.mesh, target);
+        e.fireTimer = 1.6 + Math.random() * 1.5;
+      }
+
+      if (e.mesh.position.z > KILL_Z) {
+        this.scene.remove(e.mesh);
+        this.enemies.splice(i, 1);
+        continue;
+      }
+
+      for (let j = this.bullets.length - 1; j >= 0; j -= 1) {
+        const b = this.bullets[j];
+        if (!b.friendly) continue;
+        if (distSq2D(b.mesh.position, e.mesh.position) < 1.6) {
+          this.spawnBurst(e.mesh.position, 0xff8844, 18);
+          this._broadcastFx(e.mesh.position, 0xff8844, 18, 0);
+          this.scene.remove(e.mesh);
+          this.scene.remove(b.mesh);
+          this.enemies.splice(i, 1);
+          this.bullets.splice(j, 1);
+          this._scoreUp(100);
+          if (Math.random() < 0.18) this.spawnPowerup(e.mesh.position);
+          break;
+        }
+      }
+    }
+
+    // Asteroids
+    for (let i = this.asteroids.length - 1; i >= 0; i -= 1) {
+      const a = this.asteroids[i];
+      a.mesh.position.z += a.speed * dt;
+      a.mesh.rotation.x += a.spin.x * dt;
+      a.mesh.rotation.y += a.spin.y * dt;
+      a.mesh.rotation.z += a.spin.z * dt;
+      if (a.mesh.position.z > KILL_Z) {
+        this.scene.remove(a.mesh);
+        this.asteroids.splice(i, 1);
+        continue;
+      }
+      for (let j = this.bullets.length - 1; j >= 0; j -= 1) {
+        const b = this.bullets[j];
+        if (!b.friendly) continue;
+        if (distSq2D(b.mesh.position, a.mesh.position) < (a.radius + 0.2) ** 2) {
+          this.spawnBurst(a.mesh.position, 0xaa9988, 12);
+          this.scene.remove(b.mesh);
+          this.bullets.splice(j, 1);
+          a.radius -= 0.3;
+          a.mesh.scale.multiplyScalar(0.7);
+          if (a.radius < 0.4) {
+            this.scene.remove(a.mesh);
+            this.asteroids.splice(i, 1);
+            this._scoreUp(25);
+          }
+          break;
+        }
+      }
+    }
+
+    // Boss
+    if (this.boss) {
+      this.boss.sweepT += dt;
+      const bm = this.boss.mesh;
+      // approach then sweep
+      if (bm.position.z < -22) {
+        bm.position.z += this.boss.speed * dt;
+      } else {
+        bm.position.x = Math.sin(this.boss.sweepT * 0.7) * 12;
+        bm.position.y = Math.cos(this.boss.sweepT * 0.5) * 5;
+      }
+      bm.rotation.y += dt * 0.6;
+      bm.rotation.z += dt * 0.3;
+      this.boss.fireTimer -= dt;
+      if (this.boss.fireTimer <= 0) {
+        // Triple spread toward random player
+        const tgt = (this.netRole !== "solo" && Math.random() < 0.5) ? this.player2 : this.player;
+        const base = new THREE.Vector3().subVectors(tgt.position, bm.position).normalize();
+        for (let k = -1; k <= 1; k += 1) {
+          const dir = base.clone();
+          dir.x += k * 0.18;
+          dir.normalize().multiplyScalar(48);
+          const bullet = createBullet(0xffaa00);
+          bullet.position.copy(bm.position);
+          bullet.position.z += 2;
+          this.scene.add(bullet);
+          this.bullets.push({ id: this.entId++, mesh: bullet, vel: dir, friendly: false });
+        }
+        this.boss.fireTimer = 1.0;
+      }
+      // Bullet hits
+      for (let j = this.bullets.length - 1; j >= 0; j -= 1) {
+        const b = this.bullets[j];
+        if (!b.friendly) continue;
+        if (distSq2D(b.mesh.position, bm.position) < 4.5) {
+          this.spawnBurst(b.mesh.position, 0xffcc66, 8);
+          this.scene.remove(b.mesh);
+          this.bullets.splice(j, 1);
+          this.boss.hp -= 1;
+          this.cameraShake = Math.max(this.cameraShake, 0.15);
+          if (this.boss.hp <= 0) {
+            this.spawnBurst(bm.position, 0xffaa00, 60);
+            this._broadcastFx(bm.position, 0xffaa00, 60, 0.6);
+            this.cameraShake = Math.max(this.cameraShake, 0.6);
+            this.scene.remove(bm);
+            this.boss = null;
+            this._scoreUp(1500);
+            this.spawnPowerup({ x: 0, y: 0, z: -10 });
+            this.hud.showToast("MINI-BOSS DOWN!", 1800);
+            break;
+          }
+        }
+      }
+    }
+
+    // Player collisions (per player)
+    this._tickPlayerHits(this.player, 1, dt);
+    if (this.netRole !== "solo") this._tickPlayerHits(this.player2, 2, dt);
+
+    // Particles
+    for (let i = this.particles.length - 1; i >= 0; i -= 1) {
+      const p = this.particles[i];
+      p.life -= dt;
+      p.mesh.position.addScaledVector(p.vel, dt);
+      p.vel.multiplyScalar(0.94);
+      p.mesh.material.opacity = Math.max(0, p.life);
+      if (p.life <= 0) {
+        this.scene.remove(p.mesh);
+        this.particles.splice(i, 1);
+      }
+    }
+
+    // Wave up
+    if (this.score > 0 && this.score >= this.wave * 1000) {
+      this.wave += 1;
+      this.hud.setWave(this.wave);
+      this.hud.showToast(`WAVE ${this.wave}!`);
+    }
+
+    // Net snapshot send
+    if (this.netRole === "host") {
+      this.netSnapTimer -= dt;
+      if (this.netSnapTimer <= 0) {
+        this.netSnapTimer = 1 / 20;
+        if (this.net && this.net.conn && this.net.conn.open) {
+          this.net.send(this.buildSnapshot());
+        }
+      }
+    }
+
+    this._renderFrame(dt);
+  }
+
+  _scoreUp(n) {
+    this.score += n;
+    this.hud.setScore(this.score);
+  }
+
+  _broadcastFx(pos, color, count, shake) {
+    if (this.netRole !== "host" || !this.net || !this.net.conn || !this.net.conn.open) return;
+    this.net.send({ t: "fx", x: pos.x, y: pos.y, z: pos.z, c: color, n: count, shake });
+  }
+
+  _tickPlayerHits(ship, owner, dt) {
+    const invKey = owner === 1 ? "invuln" : "invuln2";
+    const shieldKey = owner === 1 ? "shield1" : "shield2";
+    if (this[invKey] > 0) this[invKey] -= dt;
+    if (this[invKey] > 0 || this.gameOver) return;
+    let hit = null;
+    for (const e of this.enemies) {
+      if (distSq2D(e.mesh.position, ship.position) < 1.4 ** 2) {
+        hit = { mesh: e.mesh, src: this.enemies };
+        break;
+      }
+    }
+    if (!hit) {
+      for (const a of this.asteroids) {
+        if (distSq2D(a.mesh.position, ship.position) < (a.radius + 0.6) ** 2) {
+          hit = { mesh: a.mesh, src: this.asteroids };
+          break;
+        }
+      }
+    }
+    if (!hit && this.boss && distSq2D(this.boss.mesh.position, ship.position) < 6.5 ** 2) {
+      hit = { kind: "boss" };
+    }
+    if (!hit) {
+      for (let j = this.bullets.length - 1; j >= 0; j -= 1) {
+        const b = this.bullets[j];
+        if (b.friendly) continue;
+        if (distSq2D(b.mesh.position, ship.position) < 0.6 ** 2) {
+          this.scene.remove(b.mesh);
+          this.bullets.splice(j, 1);
+          hit = { kind: "bullet" };
+          break;
+        }
+      }
+    }
+    if (!hit) return;
+    if (this[shieldKey] > 0) {
+      this[shieldKey] = 0;
+      this.spawnBurst(ship.position, 0x66e0ff, 20);
+      this._broadcastFx(ship.position, 0x66e0ff, 20, 0.2);
+      this[invKey] = 1.0;
+      this.hud.showToast("SHIELD ABSORBED!");
+      return;
+    }
+    this.spawnBurst(ship.position, owner === 1 ? 0x66e0ff : 0xff5ed1, 30);
+    this._broadcastFx(ship.position, owner === 1 ? 0x66e0ff : 0xff5ed1, 30, 0.35);
+    this.cameraShake = Math.max(this.cameraShake, 0.35);
+    this.lives -= 1;
+    this.hud.setLives(this.lives);
+    this[invKey] = 1.6;
+    if (hit.src && hit.mesh) {
+      const idx = hit.src.findIndex((o) => o.mesh === hit.mesh);
+      if (idx >= 0) {
+        this.scene.remove(hit.mesh);
+        hit.src.splice(idx, 1);
+      }
+    }
+    if (this.lives <= 0) this.endGame();
+  }
+
+  _movePlayerLocal(ship, inp, dt) {
+    const PSPEED = 26;
+    if (inp.dragging) {
+      const lerp = 1 - Math.exp(-dt * 12);
+      ship.position.x += (inp.dragX - ship.position.x) * lerp;
+      ship.position.y += (inp.dragY - ship.position.y) * lerp;
+    } else {
+      ship.position.x += (inp.x || 0) * PSPEED * dt;
+      ship.position.y += (inp.y || 0) * PSPEED * dt;
+    }
+    ship.position.x = THREE.MathUtils.clamp(ship.position.x, -FIELD_X, FIELD_X);
+    ship.position.y = THREE.MathUtils.clamp(ship.position.y, -FIELD_Y, FIELD_Y);
+    const targetRoll = -(inp.x || 0) * 0.5;
+    const targetPitch = -(inp.y || 0) * 0.25;
+    ship.rotation.z += (targetRoll - ship.rotation.z) * 0.15;
+    ship.rotation.x += (targetPitch - ship.rotation.x) * 0.15;
+    // Player blink while invuln
+    const inv = ship === this.player ? this.invuln : this.invuln2;
+    ship.visible = !(inv > 0 && Math.floor(inv * 14) % 2 === 0);
+  }
+
+  _renderFrame(_dt) {
+    // Camera follows the average of both player ships in coop, else just p1
+    let tx = this.player.position.x;
+    let ty = this.player.position.y;
+    if (this.netRole !== "solo" && this.player2.visible) {
+      tx = (this.player.position.x + this.player2.position.x) * 0.5;
+      ty = (this.player.position.y + this.player2.position.y) * 0.5;
+    }
+    const camTargetX = tx * 0.35;
+    const camTargetY = 2.2 + ty * 0.2;
+    this.camera.position.x += (camTargetX - this.camera.position.x) * 0.08;
+    this.camera.position.y += (camTargetY - this.camera.position.y) * 0.08;
+
+    // Screen shake decay
+    if (this.cameraShake > 0) {
+      const s = this.cameraShake;
+      this.camera.position.x += (Math.random() - 0.5) * s;
+      this.camera.position.y += (Math.random() - 0.5) * s;
+      this.cameraShake = Math.max(0, this.cameraShake - 0.04);
+    }
+    this.camera.lookAt(tx * 0.5, ty * 0.4, -20);
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  onResize() {
+    const w = this.container.clientWidth;
+    const h = this.container.clientHeight || w * 0.6;
+    this.width = w;
+    this.height = h;
+    this.renderer.setSize(w, h);
+    this.camera.aspect = w / h;
+    this.camera.updateProjectionMatrix();
+  }
+
+  endGame() {
+    this.gameOver = true;
+    this.running = false;
+    this.player.visible = true;
+    this.player2.visible = this.netRole !== "solo";
+    if (this.netRole === "host" && this.net && this.net.conn && this.net.conn.open) {
+      this.net.send({ t: "over", score: this.score });
+    }
+    this.hud.showBanner("GAME OVER", `Final score: ${this.score}`,
+      "BACK TO MENU", () => this.openMenu());
+  }
+}
+
+export default ThreeGame;

--- a/src/js/three3d/hud.js
+++ b/src/js/three3d/hud.js
@@ -1,0 +1,216 @@
+/**
+ * HUD overlay manager. Updates text nodes inside #hud-overlay
+ * and handles the start menu (Solo / Host / Join), in-game banners,
+ * toast popups, room-code display, and power-up indicator.
+ */
+class Hud {
+  constructor() {
+    this.root = document.getElementById("hud-overlay");
+    this.scoreEl = document.getElementById("hud-score");
+    this.livesEl = document.getElementById("hud-lives");
+    this.waveEl = document.getElementById("hud-wave");
+    this.banner = document.getElementById("hud-banner");
+    this.toast = document.getElementById("hud-toast");
+    this.powerEl = document.getElementById("hud-power");
+    this.netStatusEl = document.getElementById("hud-net");
+    this.toastTimer = null;
+  }
+
+  setScore(n) {
+    if (this.scoreEl) this.scoreEl.textContent = String(n).padStart(6, "0");
+  }
+
+  setLives(n) {
+    if (!this.livesEl) return;
+    this.livesEl.textContent = "♥".repeat(Math.max(0, n));
+  }
+
+  setWave(n) {
+    if (this.waveEl) this.waveEl.textContent = `WAVE ${n}`;
+  }
+
+  setPower(label) {
+    if (!this.powerEl) return;
+    if (!label) {
+      this.powerEl.textContent = "";
+      this.powerEl.classList.remove("visible");
+    } else {
+      this.powerEl.textContent = label;
+      this.powerEl.classList.add("visible");
+    }
+  }
+
+  setNetStatus(text) {
+    if (!this.netStatusEl) return;
+    this.netStatusEl.textContent = text || "";
+    this.netStatusEl.classList.toggle("visible", !!text);
+  }
+
+  showBanner(title, subtitle, buttonText, onStart) {
+    this._renderBanner({
+      title,
+      subtitle,
+      body: `<button class="hud-btn primary" id="hud-primary">${escapeHtml(buttonText || "START")}</button>`,
+    });
+    document.getElementById("hud-primary").onclick = () => {
+      this.hideBanner();
+      if (onStart) onStart();
+    };
+  }
+
+  showMenu({ onSolo, onHost, onJoin }) {
+    this._renderBanner({
+      title: "COSMOS WARS",
+      subtitle:
+        "WebGL space shooter · solo or two-player co-op over peer-to-peer",
+      body: `
+        <div class="hud-menu">
+          <button class="hud-btn primary" id="hud-mode-solo">SOLO</button>
+          <button class="hud-btn" id="hud-mode-host">HOST CO-OP</button>
+          <button class="hud-btn" id="hud-mode-join">JOIN CO-OP</button>
+        </div>
+        <p class="hud-hint">Move: WASD / arrows / drag &middot; Fire: Space / hold mouse</p>
+      `,
+    });
+    document.getElementById("hud-mode-solo").onclick = () => {
+      this.hideBanner();
+      if (onSolo) onSolo();
+    };
+    document.getElementById("hud-mode-host").onclick = () => {
+      if (onHost) onHost();
+    };
+    document.getElementById("hud-mode-join").onclick = () => {
+      if (onJoin) onJoin();
+    };
+  }
+
+  showHostLobby({ code, shareUrl, onCancel, onStart }) {
+    this._renderBanner({
+      title: "HOSTING",
+      subtitle: "Share this room code with player 2",
+      body: `
+        <div class="hud-room-code">${escapeHtml(code)}</div>
+        <p class="hud-hint">or send this link:</p>
+        <div class="hud-share">
+          <input class="hud-input" id="hud-share-url" readonly value="${escapeAttr(shareUrl)}" />
+          <button class="hud-btn small" id="hud-share-copy">COPY</button>
+        </div>
+        <p class="hud-status" id="hud-lobby-status">Waiting for player 2…</p>
+        <div class="hud-row">
+          <button class="hud-btn primary" id="hud-lobby-start" disabled>LAUNCH CO-OP</button>
+          <button class="hud-btn ghost" id="hud-lobby-cancel">CANCEL</button>
+        </div>
+      `,
+    });
+    document.getElementById("hud-share-copy").onclick = async () => {
+      const v = document.getElementById("hud-share-url").value;
+      try {
+        await navigator.clipboard.writeText(v);
+        this.showToast("Link copied!");
+      } catch (_) {
+        document.getElementById("hud-share-url").select();
+      }
+    };
+    document.getElementById("hud-lobby-cancel").onclick = () => {
+      if (onCancel) onCancel();
+    };
+    document.getElementById("hud-lobby-start").onclick = () => {
+      this.hideBanner();
+      if (onStart) onStart();
+    };
+  }
+
+  setLobbyConnected(connected) {
+    const status = document.getElementById("hud-lobby-status");
+    const btn = document.getElementById("hud-lobby-start");
+    if (status)
+      status.textContent = connected
+        ? "Player 2 connected — ready to launch!"
+        : "Waiting for player 2…";
+    if (btn) btn.disabled = !connected;
+  }
+
+  showJoinForm({ onCancel, onJoin, prefillCode }) {
+    this._renderBanner({
+      title: "JOIN CO-OP",
+      subtitle: "Enter the room code from your friend",
+      body: `
+        <input class="hud-input big" id="hud-join-code" maxlength="8"
+               placeholder="ROOM CODE" value="${escapeAttr(prefillCode || "")}" />
+        <p class="hud-status" id="hud-join-status"></p>
+        <div class="hud-row">
+          <button class="hud-btn primary" id="hud-join-go">CONNECT</button>
+          <button class="hud-btn ghost" id="hud-join-cancel">CANCEL</button>
+        </div>
+      `,
+    });
+    const input = document.getElementById("hud-join-code");
+    input.focus();
+    input.addEventListener("input", () => {
+      input.value = input.value.toUpperCase();
+    });
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") document.getElementById("hud-join-go").click();
+    });
+    document.getElementById("hud-join-cancel").onclick = () => {
+      if (onCancel) onCancel();
+    };
+    document.getElementById("hud-join-go").onclick = () => {
+      const code = input.value.trim().toUpperCase();
+      if (code.length < 3) {
+        document.getElementById("hud-join-status").textContent =
+          "Code looks too short.";
+        return;
+      }
+      if (onJoin) onJoin(code);
+    };
+  }
+
+  setJoinStatus(text) {
+    const el = document.getElementById("hud-join-status");
+    if (el) el.textContent = text || "";
+  }
+
+  hideBanner() {
+    if (this.banner) this.banner.classList.remove("visible");
+  }
+
+  showToast(text, ms = 1400) {
+    if (!this.toast) return;
+    this.toast.textContent = text;
+    this.toast.classList.add("visible");
+    if (this.toastTimer) clearTimeout(this.toastTimer);
+    this.toastTimer = setTimeout(() => {
+      this.toast.classList.remove("visible");
+    }, ms);
+  }
+
+  _renderBanner({ title, subtitle, body }) {
+    if (!this.banner) return;
+    this.banner.innerHTML = `
+      <div class="hud-banner-title">${escapeHtml(title)}</div>
+      <div class="hud-banner-sub">${escapeHtml(subtitle || "")}</div>
+      <div class="hud-banner-body">${body}</div>
+    `;
+    this.banner.classList.add("visible");
+  }
+}
+
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c],
+  );
+}
+function escapeAttr(s) {
+  return escapeHtml(s);
+}
+
+export default Hud;

--- a/src/js/three3d/models.js
+++ b/src/js/three3d/models.js
@@ -1,0 +1,269 @@
+import * as THREE from "three";
+
+/**
+ * Procedurally builds a player starfighter from primitive geometries.
+ * Returns a THREE.Group with the ship pre-oriented (nose toward -Z).
+ */
+export function createPlayerShip() {
+  const group = new THREE.Group();
+  group.name = "PlayerShip";
+
+  const hullMat = new THREE.MeshStandardMaterial({
+    color: 0x6ed4ff,
+    metalness: 0.7,
+    roughness: 0.3,
+    emissive: 0x0a2a3a,
+  });
+  const accentMat = new THREE.MeshStandardMaterial({
+    color: 0xff5ed1,
+    metalness: 0.6,
+    roughness: 0.35,
+    emissive: 0x401030,
+  });
+  const glassMat = new THREE.MeshStandardMaterial({
+    color: 0x111a2e,
+    metalness: 0.9,
+    roughness: 0.05,
+    emissive: 0x002233,
+  });
+  const engineMat = new THREE.MeshStandardMaterial({
+    color: 0xffffff,
+    emissive: 0x66e0ff,
+    emissiveIntensity: 2.5,
+  });
+
+  // Body — elongated bevelled hull
+  const body = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.35, 0.55, 2.2, 12),
+    hullMat,
+  );
+  body.rotation.x = Math.PI / 2;
+  group.add(body);
+
+  // Nose cone
+  const nose = new THREE.Mesh(new THREE.ConeGeometry(0.35, 0.9, 12), accentMat);
+  nose.rotation.x = -Math.PI / 2;
+  nose.position.z = -1.55;
+  group.add(nose);
+
+  // Cockpit glass
+  const cockpit = new THREE.Mesh(
+    new THREE.SphereGeometry(0.32, 16, 12, 0, Math.PI * 2, 0, Math.PI / 2),
+    glassMat,
+  );
+  cockpit.position.set(0, 0.25, -0.2);
+  group.add(cockpit);
+
+  // Wings
+  const wingGeo = new THREE.BoxGeometry(2.4, 0.08, 0.9);
+  const wing = new THREE.Mesh(wingGeo, hullMat);
+  wing.position.z = 0.2;
+  group.add(wing);
+
+  const wingTip = new THREE.Mesh(
+    new THREE.BoxGeometry(0.18, 0.18, 0.6),
+    accentMat,
+  );
+  wingTip.position.set(1.2, 0, 0.2);
+  group.add(wingTip);
+  const wingTip2 = wingTip.clone();
+  wingTip2.position.x = -1.2;
+  group.add(wingTip2);
+
+  // Twin engines glow at tail
+  const eng1 = new THREE.Mesh(new THREE.CircleGeometry(0.25, 16), engineMat);
+  eng1.position.set(0.35, 0, 1.1);
+  eng1.rotation.y = Math.PI;
+  group.add(eng1);
+  const eng2 = eng1.clone();
+  eng2.position.x = -0.35;
+  group.add(eng2);
+
+  // Engine point lights for bloom feel even without postprocess
+  const light1 = new THREE.PointLight(0x66e0ff, 1.4, 6, 2);
+  light1.position.set(0, 0, 1.5);
+  group.add(light1);
+
+  return group;
+}
+
+/** A simple angular enemy fighter (red/orange) facing +Z (toward camera). */
+export function createEnemyShip() {
+  const group = new THREE.Group();
+  group.name = "EnemyShip";
+
+  const hullMat = new THREE.MeshStandardMaterial({
+    color: 0xff7a3a,
+    metalness: 0.6,
+    roughness: 0.4,
+    emissive: 0x331008,
+  });
+  const accentMat = new THREE.MeshStandardMaterial({
+    color: 0xffe04a,
+    metalness: 0.4,
+    roughness: 0.5,
+    emissive: 0x332200,
+  });
+
+  const body = new THREE.Mesh(new THREE.OctahedronGeometry(0.7, 0), hullMat);
+  body.scale.set(1.2, 0.5, 1.4);
+  group.add(body);
+
+  const wing = new THREE.Mesh(new THREE.BoxGeometry(2.0, 0.05, 0.5), accentMat);
+  group.add(wing);
+
+  const core = new THREE.Mesh(
+    new THREE.SphereGeometry(0.18, 12, 10),
+    new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      emissive: 0xff3300,
+      emissiveIntensity: 2.5,
+    }),
+  );
+  core.position.z = 0.1;
+  group.add(core);
+
+  return group;
+}
+
+/** Glowing bullet projectile. */
+export function createBullet(color = 0x66e0ff) {
+  const geo = new THREE.CapsuleGeometry(0.08, 0.5, 4, 8);
+  const mat = new THREE.MeshStandardMaterial({
+    color: 0xffffff,
+    emissive: color,
+    emissiveIntensity: 4,
+  });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.rotation.x = Math.PI / 2;
+  return mesh;
+}
+
+/** Tumbling asteroid. */
+export function createAsteroid(radius = 0.8) {
+  const geo = new THREE.IcosahedronGeometry(radius, 0);
+  // Distort vertices for irregular shape
+  const pos = geo.attributes.position;
+  for (let i = 0; i < pos.count; i += 1) {
+    const f = 0.7 + Math.random() * 0.6;
+    pos.setXYZ(i, pos.getX(i) * f, pos.getY(i) * f, pos.getZ(i) * f);
+  }
+  geo.computeVertexNormals();
+  const mat = new THREE.MeshStandardMaterial({
+    color: 0x6a6a78,
+    metalness: 0.2,
+    roughness: 0.95,
+    flatShading: true,
+  });
+  return new THREE.Mesh(geo, mat);
+}
+
+/** Player-2 starfighter — same shape, swapped palette (magenta/cyan). */
+export function createPlayer2Ship() {
+  const ship = createPlayerShip();
+  ship.name = "Player2Ship";
+  // Recolor the major materials so the two ships are easy to tell apart.
+  ship.traverse((o) => {
+    if (!o.isMesh) return;
+    const m = o.material;
+    if (m && m.color && m.emissive) {
+      const hex = m.color.getHex();
+      if (hex === 0x6ed4ff) {
+        m.color.setHex(0xff5ed1);
+        m.emissive.setHex(0x3a0a2a);
+      } else if (hex === 0xff5ed1) {
+        m.color.setHex(0xb8ff5e);
+        m.emissive.setHex(0x123a08);
+      } else if (m.emissive.getHex() === 0x66e0ff) {
+        m.emissive.setHex(0xff5ed1);
+      }
+    }
+  });
+  // Engine point light too
+  ship.traverse((o) => {
+    if (o.isPointLight) o.color.setHex(0xff5ed1);
+  });
+  return ship;
+}
+
+/** Floating, spinning, color-coded power-up pickup. */
+export function createPowerup(kind = "rapid") {
+  const palette = {
+    rapid: { color: 0xffd24a, emissive: 0xaa6600 },
+    triple: { color: 0x6affc8, emissive: 0x008855 },
+    shield: { color: 0x6ed4ff, emissive: 0x002a55 },
+  };
+  const p = palette[kind] || palette.rapid;
+  const group = new THREE.Group();
+  group.userData.kind = kind;
+
+  const core = new THREE.Mesh(
+    new THREE.IcosahedronGeometry(0.45, 0),
+    new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      emissive: p.emissive,
+      emissiveIntensity: 1.8,
+      metalness: 0.4,
+      roughness: 0.3,
+    }),
+  );
+  group.add(core);
+
+  const ring = new THREE.Mesh(
+    new THREE.TorusGeometry(0.7, 0.06, 8, 24),
+    new THREE.MeshStandardMaterial({
+      color: p.color,
+      emissive: p.emissive,
+      emissiveIntensity: 1.2,
+      metalness: 0.6,
+      roughness: 0.2,
+    }),
+  );
+  group.add(ring);
+  group.userData.ring = ring;
+
+  const light = new THREE.PointLight(p.color, 1.0, 5, 2);
+  group.add(light);
+  return group;
+}
+
+/** Mini-boss — chunkier, glowy, 3 nested rings. */
+export function createBoss() {
+  const group = new THREE.Group();
+  group.name = "Boss";
+  const hull = new THREE.MeshStandardMaterial({
+    color: 0xff3355,
+    metalness: 0.7,
+    roughness: 0.3,
+    emissive: 0x550011,
+  });
+  const accent = new THREE.MeshStandardMaterial({
+    color: 0xffaa00,
+    metalness: 0.6,
+    roughness: 0.4,
+    emissive: 0x553300,
+  });
+  const body = new THREE.Mesh(new THREE.IcosahedronGeometry(2.0, 0), hull);
+  group.add(body);
+  for (let i = 0; i < 3; i += 1) {
+    const ring = new THREE.Mesh(
+      new THREE.TorusGeometry(2.4 + i * 0.4, 0.12, 10, 32),
+      accent,
+    );
+    ring.rotation.x = (i * Math.PI) / 3;
+    ring.rotation.y = (i * Math.PI) / 4;
+    group.add(ring);
+  }
+  const core = new THREE.Mesh(
+    new THREE.SphereGeometry(0.6, 16, 12),
+    new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      emissive: 0xff5500,
+      emissiveIntensity: 3,
+    }),
+  );
+  group.add(core);
+  const light = new THREE.PointLight(0xff5500, 2.0, 14, 2);
+  group.add(light);
+  return group;
+}

--- a/src/js/three3d/net.js
+++ b/src/js/three3d/net.js
@@ -1,0 +1,136 @@
+import { Peer } from "peerjs";
+
+// Tiny PeerJS wrapper for 2-player co-op.
+// Uses the public PeerServer broker (free, works from static GitHub Pages).
+// Host generates a room code; client connects with that code.
+// Game data flows over a single WebRTC DataChannel.
+
+const ROOM_PREFIX = "cosmoswars-"; // namespace so we don't collide with random peers
+
+function randomCode(len = 5) {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // omit confusables
+  let out = "";
+  for (let i = 0; i < len; i += 1) {
+    out += alphabet[Math.floor(Math.random() * alphabet.length)];
+  }
+  return out;
+}
+
+export class NetHost {
+  constructor() {
+    this.role = "host";
+    this.code = randomCode();
+    this.conn = null;
+    this.onOpen = null; // called when remote client connects
+    this.onClose = null;
+    this.onMessage = null; // called with parsed JSON messages from client
+    this.onStatus = null; // called with human-readable status updates
+    this.peer = new Peer(ROOM_PREFIX + this.code, { debug: 1 });
+    this.peer.on("open", () => {
+      if (this.onStatus) this.onStatus(`Room ${this.code} ready. Waiting…`);
+    });
+    this.peer.on("error", (err) => {
+      if (this.onStatus) this.onStatus(`Net error: ${err.type || err.message}`);
+    });
+    this.peer.on("connection", (conn) => {
+      this.conn = conn;
+      conn.on("open", () => {
+        if (this.onStatus) this.onStatus("Player 2 connected!");
+        if (this.onOpen) this.onOpen();
+      });
+      conn.on("data", (raw) => {
+        try {
+          const msg = typeof raw === "string" ? JSON.parse(raw) : raw;
+          if (this.onMessage) this.onMessage(msg);
+        } catch (_) {
+          /* ignore malformed */
+        }
+      });
+      conn.on("close", () => {
+        this.conn = null;
+        if (this.onStatus) this.onStatus("Player 2 disconnected.");
+        if (this.onClose) this.onClose();
+      });
+    });
+  }
+
+  send(msg) {
+    if (this.conn && this.conn.open) this.conn.send(JSON.stringify(msg));
+  }
+
+  destroy() {
+    try {
+      if (this.conn) this.conn.close();
+    } catch (_) {
+      /* ignore */
+    }
+    try {
+      if (this.peer) this.peer.destroy();
+    } catch (_) {
+      /* ignore */
+    }
+  }
+}
+
+export class NetClient {
+  constructor(code) {
+    this.role = "client";
+    this.code = String(code || "")
+      .trim()
+      .toUpperCase();
+    this.conn = null;
+    this.onOpen = null;
+    this.onClose = null;
+    this.onMessage = null;
+    this.onStatus = null;
+    this.peer = new Peer({ debug: 1 });
+    this.peer.on("open", () => {
+      if (this.onStatus) this.onStatus(`Connecting to ${this.code}…`);
+      const conn = this.peer.connect(ROOM_PREFIX + this.code, {
+        reliable: false, // unreliable+ordered = lower-latency, suits realtime
+      });
+      this.conn = conn;
+      conn.on("open", () => {
+        if (this.onStatus) this.onStatus("Connected!");
+        if (this.onOpen) this.onOpen();
+      });
+      conn.on("data", (raw) => {
+        try {
+          const msg = typeof raw === "string" ? JSON.parse(raw) : raw;
+          if (this.onMessage) this.onMessage(msg);
+        } catch (_) {
+          /* ignore */
+        }
+      });
+      conn.on("close", () => {
+        this.conn = null;
+        if (this.onStatus) this.onStatus("Host disconnected.");
+        if (this.onClose) this.onClose();
+      });
+      conn.on("error", (err) => {
+        if (this.onStatus)
+          this.onStatus(`Connect error: ${err.type || err.message}`);
+      });
+    });
+    this.peer.on("error", (err) => {
+      if (this.onStatus) this.onStatus(`Net error: ${err.type || err.message}`);
+    });
+  }
+
+  send(msg) {
+    if (this.conn && this.conn.open) this.conn.send(JSON.stringify(msg));
+  }
+
+  destroy() {
+    try {
+      if (this.conn) this.conn.close();
+    } catch (_) {
+      /* ignore */
+    }
+    try {
+      if (this.peer) this.peer.destroy();
+    } catch (_) {
+      /* ignore */
+    }
+  }
+}

--- a/src/js/three3d/starfield.js
+++ b/src/js/three3d/starfield.js
@@ -1,0 +1,66 @@
+import * as THREE from "three";
+
+/**
+ * Builds a 3-layer parallax starfield + nebula sky for a 3D scene.
+ * Stars are large THREE.Points clouds positioned far from origin.
+ */
+export function createStarfield(scene) {
+  // Distant stars (white/blue)
+  const geom = new THREE.BufferGeometry();
+  const COUNT = 1500;
+  const positions = new Float32Array(COUNT * 3);
+  const colors = new Float32Array(COUNT * 3);
+  for (let i = 0; i < COUNT; i += 1) {
+    const r = 200 + Math.random() * 600;
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.acos(2 * Math.random() - 1);
+    const x = r * Math.sin(phi) * Math.cos(theta);
+    const y = r * Math.sin(phi) * Math.sin(theta);
+    const z = r * Math.cos(phi);
+    positions.set([x, y, z], i * 3);
+    const c = 0.6 + Math.random() * 0.4;
+    colors.set([c, c, Math.min(1, c + 0.15)], i * 3);
+  }
+  geom.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geom.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  const mat = new THREE.PointsMaterial({
+    size: 1.6,
+    sizeAttenuation: true,
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.9,
+  });
+  const stars = new THREE.Points(geom, mat);
+  scene.add(stars);
+
+  // Closer dust layer
+  const geom2 = new THREE.BufferGeometry();
+  const COUNT2 = 600;
+  const positions2 = new Float32Array(COUNT2 * 3);
+  for (let i = 0; i < COUNT2; i += 1) {
+    positions2.set(
+      [
+        (Math.random() - 0.5) * 200,
+        (Math.random() - 0.5) * 200,
+        -Math.random() * 400,
+      ],
+      i * 3,
+    );
+  }
+  geom2.setAttribute("position", new THREE.BufferAttribute(positions2, 3));
+  const mat2 = new THREE.PointsMaterial({
+    color: 0xa8c8ff,
+    size: 0.8,
+    sizeAttenuation: true,
+    transparent: true,
+    opacity: 0.55,
+  });
+  const dust = new THREE.Points(geom2, mat2);
+  scene.add(dust);
+
+  // Set deep-space fog/clear color
+  scene.background = new THREE.Color(0x05060d);
+  scene.fog = new THREE.Fog(0x05060d, 60, 220);
+
+  return { stars, dust };
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1,9 +1,166 @@
-body {
-  margin: 1%;
-  padding: 1%;
-  width: 100%;
-  height: auto;
-  background-color: black;
+/* ---------- Cosmos Wars — page chrome ---------- */
+
+:root {
+  --bg-0: #05060d;
+  --bg-1: #0b0f24;
+  --neon-cyan: #5ef0ff;
+  --neon-magenta: #ff5ed1;
+  --neon-violet: #9a6bff;
+  --text: #e6f1ff;
+  --text-dim: #8a9bd1;
+  --frame-glow: 0 0 24px rgba(94, 240, 255, 0.35),
+                0 0 60px rgba(154, 107, 255, 0.25);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  font-family: 'Segoe UI', 'Helvetica Neue', system-ui, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(ellipse at 20% 10%, rgba(154, 107, 255, 0.18), transparent 55%),
+    radial-gradient(ellipse at 85% 90%, rgba(94, 240, 255, 0.14), transparent 60%),
+    linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 60%, var(--bg-0) 100%);
+  background-attachment: fixed;
+  overflow-x: hidden;
+}
+
+/* Subtle starfield */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    radial-gradient(1px 1px at 12% 22%, #fff, transparent 60%),
+    radial-gradient(1px 1px at 78% 14%, #cfe9ff, transparent 60%),
+    radial-gradient(1.5px 1.5px at 44% 67%, #fff, transparent 60%),
+    radial-gradient(1px 1px at 88% 78%, #c9bfff, transparent 60%),
+    radial-gradient(1px 1px at 33% 88%, #fff, transparent 60%),
+    radial-gradient(1.5px 1.5px at 62% 38%, #b6f0ff, transparent 60%);
+  opacity: 0.7;
+  animation: drift 60s linear infinite;
+}
+@keyframes drift {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-40px); }
+}
+
+.stage {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 28px 16px 40px;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+}
+
+.topbar { text-align: center; width: 100%; }
+
+.brand {
+  margin: 0;
+  font-size: clamp(28px, 4vw, 40px);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 28px rgba(154, 107, 255, 0.35);
+}
+
+.brand-glyph {
+  display: inline-block;
+  margin-right: 8px;
+  -webkit-text-fill-color: var(--neon-cyan);
+  color: var(--neon-cyan);
+  text-shadow: 0 0 12px var(--neon-cyan);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 0.85; transform: translateY(0); }
+  50%      { opacity: 1; transform: translateY(-2px); }
+}
+
+.tagline {
+  margin: 6px 0 0;
+  color: var(--text-dim);
+  font-size: 14px;
+  letter-spacing: 0.04em;
+}
+
+.game-frame {
+  position: relative;
+  padding: 10px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(94, 240, 255, 0.06), rgba(255, 94, 209, 0.06));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--frame-glow);
+}
+
+.game-frame::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 16px;
+  padding: 1px;
+  background: linear-gradient(135deg, var(--neon-cyan), var(--neon-magenta), var(--neon-violet));
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.game-canvas {
+  border-radius: 8px;
+  overflow: hidden;
+  background: #000;
+  line-height: 0;
+}
+.game-canvas canvas {
+  display: block;
+  border-radius: 8px;
+}
+
+.bottombar {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-dim);
+  letter-spacing: 0.06em;
+}
+.bottombar .version { opacity: 0.7; }
+
+/* rexUI DOM input */
+input[type='text'] {
+  background: rgba(10, 14, 32, 0.85);
+  color: var(--text);
+  border: 1px solid rgba(94, 240, 255, 0.45);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-family: inherit;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+  outline: none;
+  box-shadow: 0 0 10px rgba(94, 240, 255, 0.25) inset;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+input[type='text']:focus {
+  border-color: var(--neon-magenta);
+  box-shadow: 0 0 14px rgba(255, 94, 209, 0.45) inset,
+              0 0 12px rgba(255, 94, 209, 0.35);
+}
+input[type='text']::placeholder { color: var(--text-dim); opacity: 0.7; }
+
+@media (max-width: 540px) {
+  .stage { padding: 16px 8px 24px; }
+  .bottombar { flex-direction: column; align-items: center; text-align: center; }
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -8,21 +8,32 @@
   --neon-violet: #9a6bff;
   --text: #e6f1ff;
   --text-dim: #8a9bd1;
-  --frame-glow: 0 0 24px rgba(94, 240, 255, 0.35),
-                0 0 60px rgba(154, 107, 255, 0.25);
+  --frame-glow:
+    0 0 24px rgba(94, 240, 255, 0.35), 0 0 60px rgba(154, 107, 255, 0.25);
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  font-family: 'Segoe UI', 'Helvetica Neue', system-ui, sans-serif;
+  font-family: "Segoe UI", "Helvetica Neue", system-ui, sans-serif;
   color: var(--text);
   background:
-    radial-gradient(ellipse at 20% 10%, rgba(154, 107, 255, 0.18), transparent 55%),
-    radial-gradient(ellipse at 85% 90%, rgba(94, 240, 255, 0.14), transparent 60%),
+    radial-gradient(
+      ellipse at 20% 10%,
+      rgba(154, 107, 255, 0.18),
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse at 85% 90%,
+      rgba(94, 240, 255, 0.14),
+      transparent 60%
+    ),
     linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 60%, var(--bg-0) 100%);
   background-attachment: fixed;
   overflow-x: hidden;
@@ -30,7 +41,7 @@ html, body {
 
 /* Subtle starfield */
 body::before {
-  content: '';
+  content: "";
   position: fixed;
   inset: 0;
   pointer-events: none;
@@ -45,8 +56,12 @@ body::before {
   animation: drift 60s linear infinite;
 }
 @keyframes drift {
-  from { transform: translateY(0); }
-  to   { transform: translateY(-40px); }
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-40px);
+  }
 }
 
 .stage {
@@ -59,7 +74,10 @@ body::before {
   gap: 18px;
 }
 
-.topbar { text-align: center; width: 100%; }
+.topbar {
+  text-align: center;
+  width: 100%;
+}
 
 .brand {
   margin: 0;
@@ -83,8 +101,15 @@ body::before {
   animation: pulse 2.4s ease-in-out infinite;
 }
 @keyframes pulse {
-  0%, 100% { opacity: 0.85; transform: translateY(0); }
-  50%      { opacity: 1; transform: translateY(-2px); }
+  0%,
+  100% {
+    opacity: 0.85;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
 }
 
 .tagline {
@@ -97,27 +122,43 @@ body::before {
 .game-frame {
   position: relative;
   padding: 10px;
+  width: 100%;
+  max-width: 740px;
   border-radius: 14px;
-  background: linear-gradient(135deg, rgba(94, 240, 255, 0.06), rgba(255, 94, 209, 0.06));
+  background: linear-gradient(
+    135deg,
+    rgba(94, 240, 255, 0.06),
+    rgba(255, 94, 209, 0.06)
+  );
   border: 1px solid rgba(255, 255, 255, 0.06);
   box-shadow: var(--frame-glow);
 }
 
 .game-frame::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: -2px;
   border-radius: 16px;
   padding: 1px;
-  background: linear-gradient(135deg, var(--neon-cyan), var(--neon-magenta), var(--neon-violet));
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  background: linear-gradient(
+    135deg,
+    var(--neon-cyan),
+    var(--neon-magenta),
+    var(--neon-violet)
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
-          mask-composite: exclude;
+  mask-composite: exclude;
   opacity: 0.55;
   pointer-events: none;
 }
 
 .game-canvas {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 10;
   border-radius: 8px;
   overflow: hidden;
   background: #000;
@@ -125,7 +166,175 @@ body::before {
 }
 .game-canvas canvas {
   display: block;
+  width: 100% !important;
+  height: 100% !important;
   border-radius: 8px;
+}
+
+/* ---------- 3D HUD overlay ---------- */
+#hud-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  color: var(--text);
+  z-index: 2;
+}
+
+.hud-top {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  padding: 14px 18px;
+  gap: 10px;
+  background: linear-gradient(180deg, rgba(5, 6, 13, 0.55), transparent);
+}
+.hud-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.hud-cell-center {
+  align-items: center;
+  justify-content: center;
+}
+.hud-cell-right {
+  align-items: flex-end;
+}
+
+.hud-label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: var(--text-dim);
+}
+.hud-value {
+  font-family: "JetBrains Mono", "Menlo", monospace;
+  font-size: 18px;
+  letter-spacing: 0.12em;
+  text-shadow: 0 0 8px rgba(94, 240, 255, 0.55);
+  color: var(--neon-cyan);
+}
+.hud-lives {
+  color: var(--neon-magenta);
+  text-shadow: 0 0 8px rgba(255, 94, 209, 0.55);
+}
+
+.hud-toast {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.9);
+  padding: 8px 18px;
+  background: rgba(11, 15, 36, 0.7);
+  border: 1px solid rgba(94, 240, 255, 0.5);
+  border-radius: 999px;
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 10px rgba(94, 240, 255, 0.6);
+  opacity: 0;
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s ease;
+}
+.hud-toast.visible {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.hud-banner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: radial-gradient(
+    circle at center,
+    rgba(11, 15, 36, 0.55),
+    rgba(5, 6, 13, 0.85)
+  );
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+.hud-banner.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.hud-banner-title {
+  font-size: clamp(28px, 5vw, 48px);
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 28px rgba(154, 107, 255, 0.4);
+}
+.hud-banner-sub {
+  font-size: 13px;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  text-align: center;
+  max-width: 80%;
+}
+
+.hud-btn {
+  margin-top: 8px;
+  padding: 12px 32px;
+  font: inherit;
+  font-size: 14px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--text);
+  background: linear-gradient(
+    135deg,
+    rgba(94, 240, 255, 0.18),
+    rgba(255, 94, 209, 0.18)
+  );
+  border: 1px solid var(--neon-cyan);
+  border-radius: 999px;
+  cursor: pointer;
+  pointer-events: auto;
+  box-shadow:
+    0 0 18px rgba(94, 240, 255, 0.45),
+    inset 0 0 12px rgba(94, 240, 255, 0.25);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+.hud-btn:hover {
+  transform: translateY(-1px) scale(1.04);
+  border-color: var(--neon-magenta);
+  box-shadow:
+    0 0 22px rgba(255, 94, 209, 0.55),
+    inset 0 0 14px rgba(255, 94, 209, 0.3);
+}
+.hud-btn:active {
+  transform: scale(0.97);
+}
+
+.brand-tag {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 10px;
+  font-size: 0.5em;
+  letter-spacing: 0.2em;
+  vertical-align: middle;
+  background: linear-gradient(135deg, var(--neon-cyan), var(--neon-magenta));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  border: 1px solid rgba(94, 240, 255, 0.5);
+  border-radius: 4px;
 }
 
 .bottombar {
@@ -137,10 +346,12 @@ body::before {
   color: var(--text-dim);
   letter-spacing: 0.06em;
 }
-.bottombar .version { opacity: 0.7; }
+.bottombar .version {
+  opacity: 0.7;
+}
 
 /* rexUI DOM input */
-input[type='text'] {
+input[type="text"] {
   background: rgba(10, 14, 32, 0.85);
   color: var(--text);
   border: 1px solid rgba(94, 240, 255, 0.45);
@@ -151,16 +362,169 @@ input[type='text'] {
   letter-spacing: 0.05em;
   outline: none;
   box-shadow: 0 0 10px rgba(94, 240, 255, 0.25) inset;
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  transition:
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
 }
-input[type='text']:focus {
+input[type="text"]:focus {
   border-color: var(--neon-magenta);
-  box-shadow: 0 0 14px rgba(255, 94, 209, 0.45) inset,
-              0 0 12px rgba(255, 94, 209, 0.35);
+  box-shadow:
+    0 0 14px rgba(255, 94, 209, 0.45) inset,
+    0 0 12px rgba(255, 94, 209, 0.35);
 }
-input[type='text']::placeholder { color: var(--text-dim); opacity: 0.7; }
+input[type="text"]::placeholder {
+  color: var(--text-dim);
+  opacity: 0.7;
+}
 
 @media (max-width: 540px) {
-  .stage { padding: 16px 8px 24px; }
-  .bottombar { flex-direction: column; align-items: center; text-align: center; }
+  .stage {
+    padding: 16px 8px 24px;
+  }
+  .bottombar {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
 }
+
+/* ---------- Multiplayer menu / lobby / forms ---------- */
+.hud-banner-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  width: min(420px, 86%);
+}
+.hud-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+.hud-menu .hud-btn { width: 100%; }
+.hud-btn.primary {
+  border-color: var(--neon-magenta);
+  box-shadow:
+    0 0 22px rgba(255, 94, 209, 0.55),
+    inset 0 0 14px rgba(255, 94, 209, 0.3);
+}
+.hud-btn.ghost {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.25);
+  box-shadow: none;
+  color: var(--text-dim);
+}
+.hud-btn.ghost:hover { color: var(--text); border-color: rgba(255,255,255,0.6); }
+.hud-btn.small {
+  padding: 8px 14px;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+}
+.hud-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+.hud-row {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+  justify-content: center;
+}
+.hud-hint {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: var(--text-dim);
+  text-align: center;
+}
+.hud-status {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--neon-cyan);
+  text-align: center;
+  min-height: 1.2em;
+}
+.hud-room-code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: clamp(36px, 8vw, 56px);
+  font-weight: 800;
+  letter-spacing: 0.32em;
+  padding: 10px 20px;
+  background: rgba(10, 14, 32, 0.7);
+  border: 1px solid var(--neon-cyan);
+  border-radius: 12px;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 18px rgba(94, 240, 255, 0.65);
+  box-shadow: 0 0 28px rgba(94, 240, 255, 0.35) inset;
+  user-select: all;
+}
+.hud-share {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+  align-items: stretch;
+}
+.hud-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: rgba(10, 14, 32, 0.85);
+  color: var(--text);
+  border: 1px solid rgba(94, 240, 255, 0.45);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  outline: none;
+  box-shadow: 0 0 10px rgba(94, 240, 255, 0.2) inset;
+}
+.hud-input:focus {
+  border-color: var(--neon-magenta);
+  box-shadow: 0 0 14px rgba(255, 94, 209, 0.4) inset;
+}
+.hud-input.big {
+  font-size: 22px;
+  text-align: center;
+  letter-spacing: 0.4em;
+  padding: 14px;
+}
+
+.hud-power {
+  position: absolute;
+  top: 56px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 14px;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: #ffd24a;
+  background: rgba(60, 40, 0, 0.65);
+  border: 1px solid rgba(255, 210, 74, 0.6);
+  border-radius: 999px;
+  box-shadow: 0 0 12px rgba(255, 210, 74, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+.hud-power.visible { opacity: 1; }
+
+.hud-net {
+  position: absolute;
+  bottom: 8px;
+  left: 12px;
+  padding: 3px 10px;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: var(--neon-magenta);
+  border: 1px solid rgba(255, 94, 209, 0.5);
+  border-radius: 999px;
+  background: rgba(40, 10, 30, 0.55);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+.hud-net.visible { opacity: 1; }


### PR DESCRIPTION
## What

Modernization of the game on three axes — all in one branch.

### 1. 3D rewrite (Three.js)
- Gameplay now runs in WebGL via Three.js (`src/js/three3d/`):
  - Procedural ship / enemy / asteroid / boss / power-up models built from primitive geometry (Cylinder, Cone, Octa/Icosahedron, Capsule, Torus) with PBR materials and emissive glow.
  - Starfield (1500 points) + dust layer (600 particles) + scene fog for depth.
  - Smooth camera follow + screen shake on impacts; ACES filmic tonemapping.
  - Twin-cannon firing with 3-bullet base spread (5-bullet with triple-shot power-up).
  - Mini-bosses every 3rd wave with sweeping pattern + triple-spread fire.
  - Power-ups (rapid-fire ⚡, triple-shot 🔱, shield 🛡) drop from kills; shield absorbs one hit before consuming.
  - Particle-burst explosions, brief invulnerability + blink after a hit, wave-up toast every 1000 score.

### 2. Optional 2-player WebRTC co-op
- Start menu offers **SOLO / HOST CO-OP / JOIN CO-OP**.
- Host generates a short room code (e.g. `J7Y54`) and a shareable URL — client opens `?join=J7Y54` from any device (phone or desktop) and the join form is prefilled and auto-submits.
- Wire format: WebRTC DataChannel via [PeerJS](https://peerjs.com) on the public broker — **no server to host**, fully compatible with GitHub Pages.
- Host runs the simulation and ships ~20 Hz snapshots; client sends ~30 Hz input. Both ships are color-coded (cyan = P1, magenta = P2).

### 3. UI polish + procedural music (carried over from earlier work in this branch)
- Branded "Cosmos Wars 3D" HTML shell with neon gradient title, tagline, footer hints, version badge.
- Modern dark/neon CSS theme with animated starfield + nebula background and a glowing canvas frame.
- New DOM HUD overlay: score / wave / lives + power-up pill + net-status pill + toast.
- Procedural Web Audio synth (slow saw+sine pad, triangle arpeggio, sine sub-bass; A minor 4-chord progression) replaces static `background.mp3`/`ogg`.

## Files

- New: `src/js/three3d/{game,models,starfield,hud,net}.js`
- New: `src/js/classes/util/spaceMusic.js`
- Modified: `src/index.html`, `src/styles/style.css`, `src/js/index.js`, `package.json`, `package-lock.json`
- Old Phaser scenes (`src/js/scenes/`, `src/js/classes/ui/`, etc.) are no longer instantiated at runtime but kept in the tree so the existing jest suite still passes.

## Dependencies added

- `three` ^0.169.0
- `peerjs` ^1.5.x

## Verification

- `npm test` → 10/10 suites, **17/17 tests pass**
- `npm run build` → clean (esbuild + copyfiles)
- Browser tested locally on http://localhost:8072:
  - SOLO: menu → play → game-over → BACK TO MENU loop works.
  - HOST + JOIN flow verified end-to-end with two browser pages: room code generated, share URL with `?join=` auto-fills the JOIN form, host receives "Player 2 connected" toast and the LAUNCH button activates, both color-coded ships render in the scene.